### PR TITLE
Simplify remote attribute fallback

### DIFF
--- a/addon/brailleDisplayDrivers/remote.py
+++ b/addon/brailleDisplayDrivers/remote.py
@@ -54,12 +54,7 @@ class RemoteBrailleDisplayDriver(driver.RemoteDriver, braille.BrailleDisplayDriv
 
 	def _get_numCells(self) -> int:
 		if (value := self.numRows * self.numCols) == 0:
-			attribute = protocol.BrailleAttribute.NUM_CELLS
-			try:
-				value = self._attributeValueProcessor.getValue(attribute, fallBackToDefault=False)
-			except KeyError:
-				value = self._attributeValueProcessor._getDefaultValue(attribute)
-				self.requestRemoteAttribute(attribute)
+			value = self._getRemoteAttributeValueWithFallback(protocol.BrailleAttribute.NUM_CELLS)
 		return value
 
 	@protocol.attributeReceiver(protocol.BrailleAttribute.NUM_ROWS, defaultValue=1)
@@ -68,13 +63,7 @@ class RemoteBrailleDisplayDriver(driver.RemoteDriver, braille.BrailleDisplayDriv
 		return ord(payload)
 
 	def _get_numRows(self) -> int:
-		attribute = protocol.BrailleAttribute.NUM_ROWS
-		try:
-			value = self._attributeValueProcessor.getValue(attribute, fallBackToDefault=False)
-		except KeyError:
-			value = self._attributeValueProcessor._getDefaultValue(attribute)
-			self.requestRemoteAttribute(attribute)
-		return value
+		return self._getRemoteAttributeValueWithFallback(protocol.BrailleAttribute.NUM_ROWS)
 
 	@protocol.attributeReceiver(protocol.BrailleAttribute.NUM_COLS, defaultValue=0)
 	def _incoming_numCols(self, payload: bytes) -> int:
@@ -82,13 +71,7 @@ class RemoteBrailleDisplayDriver(driver.RemoteDriver, braille.BrailleDisplayDriv
 		return ord(payload)
 
 	def _get_numCols(self) -> int:
-		attribute = protocol.BrailleAttribute.NUM_COLS
-		try:
-			value = self._attributeValueProcessor.getValue(attribute, fallBackToDefault=False)
-		except KeyError:
-			value = self._attributeValueProcessor._getDefaultValue(attribute)
-			self.requestRemoteAttribute(attribute)
-		return value
+		return self._getRemoteAttributeValueWithFallback(protocol.BrailleAttribute.NUM_COLS)
 
 	@protocol.attributeReceiver(protocol.BrailleAttribute.GESTURE_MAP)
 	def _incoming_gestureMapUpdate(self, payload: bytes) -> inputCore.GlobalGestureMap:
@@ -100,13 +83,7 @@ class RemoteBrailleDisplayDriver(driver.RemoteDriver, braille.BrailleDisplayDriv
 		return inputCore.GlobalGestureMap()
 
 	def _get_gestureMap(self) -> inputCore.GlobalGestureMap:
-		attribute = protocol.BrailleAttribute.GESTURE_MAP
-		try:
-			value = self._attributeValueProcessor.getValue(attribute, fallBackToDefault=False)
-		except KeyError:
-			value = self._attributeValueProcessor._getDefaultValue(attribute)
-			self.requestRemoteAttribute(attribute)
-		return value
+		return self._getRemoteAttributeValueWithFallback(protocol.BrailleAttribute.GESTURE_MAP)
 
 	@protocol.commandHandler(protocol.BrailleCommand.EXECUTE_GESTURE)
 	def _command_executeGesture(self, payload: bytes):

--- a/addon/lib/protocol/__init__.py
+++ b/addon/lib/protocol/__init__.py
@@ -174,6 +174,13 @@ class AttributeReceiver(AttributeHandler[AttributeReceiverUnboundT | WildCardAtt
 		return func
 
 
+def _constantDefaultValueGetter(defaultValue: Any) -> DefaultValueGetterT:
+	def _defaultValueGetter(_self: RemoteProtocolHandler, _attribute: AttributeT):
+		return defaultValue
+
+	return _defaultValueGetter
+
+
 def attributeReceiver(
 	attribute: AttributeT,
 	defaultValue: Any = None,
@@ -183,11 +190,7 @@ def attributeReceiver(
 	if defaultValue is not None and defaultValueGetter is not None:
 		raise ValueError("Either defaultValue or defaultValueGetter is required, but not both")
 	if defaultValueGetter is None:
-
-		def _defaultValueGetter(_self: RemoteProtocolHandler, _attribute: AttributeT):
-			return defaultValue
-
-		defaultValueGetter = _defaultValueGetter
+		defaultValueGetter = _constantDefaultValueGetter(defaultValue)
 	return partial(
 		AttributeReceiver,
 		attribute,
@@ -442,6 +445,14 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 			timeout -= time.perf_counter() - curTime
 		return predicate()
 
+	def _getRemoteAttributeValueWithFallback(self, attribute: AttributeT):
+		try:
+			return self._attributeValueProcessor.getValue(attribute, fallBackToDefault=False)
+		except KeyError:
+			value = self._attributeValueProcessor._getDefaultValue(attribute)
+			self.requestRemoteAttribute(attribute)
+			return value
+
 	def getRemoteAttribute(
 		self,
 		attribute: AttributeT,
@@ -510,13 +521,7 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 		return payload.decode()
 
 	def _get_nvdaVersion(self) -> str:
-		attribute = GenericAttribute.NVDA_VERSION
-		try:
-			value = self._attributeValueProcessor.getValue(attribute, fallBackToDefault=False)
-		except KeyError:
-			value = self._attributeValueProcessor._getDefaultValue(attribute)
-			self.requestRemoteAttribute(attribute)
-		return value
+		return self._getRemoteAttributeValueWithFallback(GenericAttribute.NVDA_VERSION)
 
 	@attributeSender(GenericAttribute.RD_ACCESS_VERSION)
 	def _outgoing_rdAccessVersion(self) -> bytes:
@@ -527,10 +532,4 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 		return payload.decode()
 
 	def _get_rdAccessVersion(self) -> str:
-		attribute = GenericAttribute.RD_ACCESS_VERSION
-		try:
-			value = self._attributeValueProcessor.getValue(attribute, fallBackToDefault=False)
-		except KeyError:
-			value = self._attributeValueProcessor._getDefaultValue(attribute)
-			self.requestRemoteAttribute(attribute)
-		return value
+		return self._getRemoteAttributeValueWithFallback(GenericAttribute.RD_ACCESS_VERSION)

--- a/addon/synthDrivers/remote.py
+++ b/addon/synthDrivers/remote.py
@@ -114,13 +114,7 @@ class remoteSynthDriver(driver.RemoteDriver, synthDriverHandler.SynthDriver):
 		return self._unpickle(payLoad)
 
 	def _get_supportedCommands(self):
-		attribute = protocol.SpeechAttribute.SUPPORTED_COMMANDS
-		try:
-			value = self._attributeValueProcessor.getValue(attribute, fallBackToDefault=False)
-		except KeyError:
-			value = self._attributeValueProcessor._getDefaultValue(attribute)
-			self.requestRemoteAttribute(attribute)
-		return value
+		return self._getRemoteAttributeValueWithFallback(protocol.SpeechAttribute.SUPPORTED_COMMANDS)
 
 	@protocol.attributeReceiver(protocol.SpeechAttribute.LANGUAGE, defaultValue=getLanguage())
 	def _incoming_language(self, payload: bytes) -> str | None:
@@ -128,13 +122,7 @@ class remoteSynthDriver(driver.RemoteDriver, synthDriverHandler.SynthDriver):
 		return self._unpickle(payload)
 
 	def _get_language(self):
-		attribute = protocol.SpeechAttribute.LANGUAGE
-		try:
-			value = self._attributeValueProcessor.getValue(attribute, fallBackToDefault=False)
-		except KeyError:
-			value = self._attributeValueProcessor._getDefaultValue(attribute)
-			self.requestRemoteAttribute(attribute)
-		return value
+		return self._getRemoteAttributeValueWithFallback(protocol.SpeechAttribute.LANGUAGE)
 
 	@protocol.commandHandler(protocol.SpeechCommand.INDEX_REACHED)
 	def _command_indexReached(self, incomingPayload: bytes):


### PR DESCRIPTION
## Summary
- extract shared protocol helper for remote attribute fallback reads
- replace duplicated getter boilerplate in speech and braille remote drivers
- simplify constant default handling in `attributeReceiver`

## Test plan
- [x] Run `uv run pre-commit run --all-files`
- [x] Run `uv run scons` (`msgfmt` missing in local environment)
- [ ] Manual NVDA validation in real remote session

🤖 Generated with [Claude Code](https://claude.com/claude-code)