### PR TITLE
perf: O(1) handler dispatch and cached dir() lookups

### DIFF
--- a/addon/lib/driver/__init__.py
+++ b/addon/lib/driver/__init__.py
@@ -1,6 +1,7 @@
 # RDAccess: Remote Desktop Accessibility for NVDA
 # Copyright 2023 Leonard de Ruijter <alderuijter@gmail.com>
 # License: GNU General Public License version 2.0
+from __future__ import annotations
 
 import sys
 import time
@@ -19,6 +20,10 @@ from winAPI.secureDesktop import post_secureDesktopStateChange
 from .. import inputTime, protocol, wtsVirtualChannel
 from ..detection import bgScanRD
 from .settingsAccessor import SettingsAccessorBase
+
+_AUTO_PROPERTY_OBJECT_NAMES: frozenset[str] = frozenset(
+	n for n in dir(AutoPropertyObject) if not n.startswith("_")
+)
 
 ERROR_INVALID_HANDLE = 0x6
 ERROR_PIPE_NOT_CONNECTED = 0xE9
@@ -108,12 +113,10 @@ class RemoteDriver(protocol.RemoteProtocolHandler, driverHandler.Driver):
 
 	def __getattribute__(self, name: str) -> Any:
 		getter = super().__getattribute__
-		if (name.startswith("_") and not name.startswith("_get_")) or name in (
-			n for n in dir(AutoPropertyObject) if not n.startswith("_")
-		):
+		if (name.startswith("_") and not name.startswith("_get_")) or name in _AUTO_PROPERTY_OBJECT_NAMES:
 			return getter(name)
 		accessor = getter("_settingsAccessor")
-		if accessor and name in dir(accessor):
+		if accessor and name in accessor._publicNames:
 			return getattr(accessor, name)
 		return getter(name)
 

--- a/addon/lib/driver/settingsAccessor.py
+++ b/addon/lib/driver/settingsAccessor.py
@@ -21,6 +21,7 @@ class SettingsAccessorBase(AutoPropertyObject):
 	_driverRef: weakref.ref[RemoteDriver]
 	driver: RemoteDriver
 	_settingNames: list[str]
+	_publicNames: frozenset[str]
 	cachePropertiesByDefault = True
 
 	@classmethod
@@ -52,6 +53,7 @@ class SettingsAccessorBase(AutoPropertyObject):
 		self._settingNames = settingNames
 		for name in self._settingNames:
 			driver.requestRemoteAttribute(self._getSettingAttributeName(name))
+		self._publicNames = frozenset(n for n in dir(self) if not n.startswith("_"))
 
 	@classmethod
 	def _getSettingAttributeName(cls, setting: str) -> protocol.AttributeT:

--- a/addon/lib/protocol/__init__.py
+++ b/addon/lib/protocol/__init__.py
@@ -200,8 +200,25 @@ def attributeReceiver(
 
 
 class CommandHandlerStore(HandlerRegistrar):
+	_commandIndex: dict[CommandT, CommandHandlerT]
+
+	def __init__(self, *, _deprecationMessage: str | None = None):
+		super().__init__(_deprecationMessage=_deprecationMessage)
+		self._commandIndex = {}
+
+	def register(self, handler: CommandHandlerT):
+		super().register(handler)
+		self._commandIndex[handler._command] = handler
+
+	def unregister(self, handler):
+		result = super().unregister(handler)
+		if result:
+			# handler may be a weakref wrapper at this point; rebuild index from live handlers.
+			self._commandIndex = {h._command: h for h in self.handlers}
+		return result
+
 	def _getHandler(self, command: CommandT) -> CommandHandlerT:
-		handler = next((v for v in self.handlers if command == v._command), None)
+		handler = self._commandIndex.get(command)
 		if handler is None:
 			raise NotImplementedError(f"No command handler for command {command!r}")
 		return handler
@@ -215,8 +232,42 @@ class CommandHandlerStore(HandlerRegistrar):
 class AttributeHandlerStore[
 	AttributeHandlerT: (attributeFetcherT, AttributeReceiverUnboundT, WildCardAttributeReceiverUnboundT),
 ](HandlerRegistrar[AttributeHandler]):
+	_exactIndex: dict[AttributeT, AttributeHandler]
+	_wildcardHandlers: list[AttributeHandler]
+
+	def __init__(self, *, _deprecationMessage: str | None = None):
+		super().__init__(_deprecationMessage=_deprecationMessage)
+		self._exactIndex = {}
+		self._wildcardHandlers = []
+
+	def _rebuildIndex(self):
+		self._exactIndex = {}
+		self._wildcardHandlers = []
+		for h in self.handlers:
+			if h._isCatchAll:
+				self._wildcardHandlers.append(h)
+			else:
+				self._exactIndex[h._attribute] = h
+
+	def register(self, handler: AttributeHandler):
+		super().register(handler)
+		if handler._isCatchAll:
+			self._wildcardHandlers.append(handler)
+		else:
+			self._exactIndex[handler._attribute] = handler
+
+	def unregister(self, handler):
+		result = super().unregister(handler)
+		if result:
+			self._rebuildIndex()
+		return result
+
 	def _getRawHandler(self, attribute: AttributeT) -> AttributeHandler:
-		handler = next((v for v in self.handlers if fnmatch(attribute, v._attribute)), None)
+		# Exact match takes priority over wildcard patterns (e.g. a specific attribute beats setting_*)
+		handler = self._exactIndex.get(attribute)
+		if handler is not None:
+			return handler
+		handler = next((h for h in self._wildcardHandlers if fnmatch(attribute, h._attribute)), None)
 		if handler is None:
 			raise NotImplementedError(f"No attribute sender for attribute {attribute}")
 		return handler


### PR DESCRIPTION
## Summary

- **`protocol/__init__.py`**: Replace linear O(n) scans in `CommandHandlerStore` and `AttributeHandlerStore` with indexed lookups. Commands use a `dict` for O(1) dispatch; attributes use an exact-match dict plus a short wildcard-only fallback list (`fnmatch` only over catch-all patterns like `setting_*`).
- **`driver/__init__.py`**: Add module-level `_AUTO_PROPERTY_OBJECT_NAMES` frozenset — replaces repeated `dir(AutoPropertyObject)` call in `__getattribute__`.
- **`driver/settingsAccessor.py`**: Cache accessor public names as `_publicNames` frozenset at init time — replaces repeated `dir(accessor)` call on every property access.

## Test Plan

No automated test suite. Manual verification:
- [ ] Connect NVDA on RDP/AVD server, verify speech and braille forwarding works end-to-end
- [ ] Disconnect and reconnect session, verify handlers reinitialize correctly
- [ ] Check NVDA log for unexpected errors during attribute dispatch