### PR TITLE
Rearchitect protocol handler dispatch type model

### DIFF
--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -45,6 +45,9 @@ jobs:
     - name: Code checks
       run: $env:SKIP = "no-commit-to-branch"; uv run prek run --all-files
 
+    - name: Run unit tests
+      run: uv run python -m unittest discover -s tests -t . -v
+
     - name: building addon
       run: uv run scons && uv run scons pot
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Toolchain: `uv` + SCons. Run from repo root.
 
 Git hooks run via **prek** (Rust pre-commit alternative; config in `prek.toml`). Run `uv run prek install -f` once to wire the git hooks.
 
-There is no test suite. Validation is manual against NVDA on a real RDP/Citrix session.
+Unit tests live in `tests/` (stdlib unittest): `uv run python -m unittest discover -s tests -t .`. They run without NVDA by stubbing NVDA runtime modules in `sys.modules` (`tests/_stubs.py`) and reusing the real `baseObject`/`extensionPoints` from the sibling `..\nvda\source` checkout, which must therefore be present. Tests cover `addon/lib/protocol`; integration behavior (pipes, drivers, NVDA core) is still validated manually against NVDA on a real RDP/Citrix session. The suite also runs as a prek hook and as a CI step.
 
 Type checking uses **ty** (`[tool.ty]` in `pyproject.toml`), scoped to `addon/` + `buildVars.py`. NVDA internals are resolved against a sibling `..\nvda\source` checkout, so type checking requires the NVDA source repo alongside this one (CI clones it). `wx` / `serial.win32` resolve from the `wxPython` / `pyserial` dev deps.
 

--- a/addon/lib/protocol/__init__.py
+++ b/addon/lib/protocol/__init__.py
@@ -7,7 +7,7 @@ import inspect
 import pickle
 import sys
 import time
-import types
+import weakref
 from abc import abstractmethod
 from collections import defaultdict
 from collections.abc import Callable
@@ -17,7 +17,6 @@ from fnmatch import fnmatch
 from functools import partial, update_wrapper, wraps
 from typing import (
 	Any,
-	TypeVar,
 	cast,
 )
 
@@ -25,7 +24,6 @@ import addonHandler
 import queueHandler
 import versionInfo
 from baseObject import AutoPropertyObject
-from extensionPoints import HandlerRegistrar
 from hwIo.base import IoBase
 from logHandler import log
 
@@ -53,30 +51,28 @@ class GenericAttribute(bytes, Enum):
 	RD_ACCESS_VERSION = b"rdAccessVersion"
 
 
-RemoteProtocolHandlerT = TypeVar("RemoteProtocolHandlerT", bound="RemoteProtocolHandler")
-HandlerFuncT = TypeVar("HandlerFuncT", bound=Callable)
-AttributeValueT = TypeVar("AttributeValueT")
 CommandT = GenericCommand | SpeechCommand | BrailleCommand
-CommandHandlerUnboundT = Callable[[RemoteProtocolHandlerT, bytes], None]
-CommandHandlerT = Callable[[bytes], None]
 AttributeT = GenericAttribute | SpeechAttribute | BrailleAttribute | bytes
-attributeFetcherT = Callable[..., bytes]
-attributeSenderT = Callable[..., None]
-AttributeReceiverT = Callable[[bytes], AttributeValueT]
-AttributeReceiverUnboundT = Callable[[RemoteProtocolHandlerT, bytes], AttributeValueT]
-WildCardAttributeReceiverT = Callable[[AttributeT, bytes], AttributeValueT]
-WildCardAttributeReceiverUnboundT = Callable[[RemoteProtocolHandlerT, AttributeT, bytes], AttributeValueT]
-AttributeHandlerT = TypeVar(
-	"AttributeHandlerT",
-	attributeFetcherT,
-	AttributeReceiverUnboundT,
-	WildCardAttributeReceiverUnboundT,
-)
-DefaultValueGetterT = Callable[[RemoteProtocolHandlerT, AttributeT], AttributeValueT]
-AttributeValueUpdateCallbackT = Callable[[RemoteProtocolHandlerT, AttributeT, AttributeValueT], None]
+# Handler functions are stored unbound; the first parameter is the RemoteProtocolHandler instance.
+# It is typed as Any because typing it precisely would make subclass methods (whose self is the
+# subclass) unassignable due to parameter contravariance.
+CommandHandlerFuncT = Callable[[Any, bytes], None]
+# Attribute handler functions vary in arity: catch-all handlers receive the concrete attribute as an
+# extra argument and senders may take additional (keyword) arguments.
+AttributeFetcherT = Callable[..., bytes]
+AttributeReceiverFuncT = Callable[..., Any]
+DefaultValueGetterT = Callable[[Any, AttributeT], Any]
+AttributeValueUpdateCallbackT = Callable[[Any, AttributeT, Any], None]
 
 
 class HandlerDecoratorBase[HandlerFuncT: Callable]:
+	"""Decorator that marks a method as a protocol handler.
+
+	Instances live on the class and hold the decorated function unbound;
+	RemoteProtocolHandler.__new__ registers them on the per-instance handler stores,
+	which pass the owning instance explicitly on dispatch.
+	"""
+
 	_func: HandlerFuncT
 
 	def __init__(self, func: HandlerFuncT):
@@ -88,42 +84,34 @@ class HandlerDecoratorBase[HandlerFuncT: Callable]:
 
 	def __call__(self, *args, **kwargs):
 		# Concrete subclasses implement the actual dispatch; declaring it here lets the type
-		# checker treat instances as callable (used by update_wrapper and MethodType above).
+		# checker treat instances as callable (used by update_wrapper).
 		raise NotImplementedError
 
-	def __get__(self, obj, objtype=None):
-		if obj is None:
-			return self
-		return types.MethodType(self, obj)
 
-
-class CommandHandler(HandlerDecoratorBase[CommandHandlerT]):
+class CommandHandler(HandlerDecoratorBase[CommandHandlerFuncT]):
 	_command: CommandT
 
-	def __init__(self, command: CommandT, func: CommandHandlerT):
+	def __init__(self, command: CommandT, func: CommandHandlerFuncT):
 		super().__init__(func)
 		self._command = command
 
 	def __call__(self, protocolHandler: RemoteProtocolHandler, payload: bytes):
 		log.debug(f"Calling {self!r} for command {self._command!r}")
-		# _func holds the unbound handler; the bound/unbound alias conflation confuses ty. See #59.
-		return self._func(protocolHandler, payload)  # ty: ignore[invalid-argument-type, too-many-positional-arguments]
+		return self._func(protocolHandler, payload)
 
 
 def commandHandler(command: CommandT):
 	return partial(CommandHandler, command)
 
 
-class AttributeHandler[
-	AttributeHandlerT: (attributeFetcherT, AttributeReceiverUnboundT, WildCardAttributeReceiverUnboundT),
-](HandlerDecoratorBase):
+class AttributeHandler[AttributeHandlerFuncT: Callable](HandlerDecoratorBase[AttributeHandlerFuncT]):
 	_attribute: AttributeT = b""
 
 	@property
 	def _isCatchAll(self) -> bool:
 		return b"*" in self._attribute
 
-	def __init__(self, attribute: AttributeT, func: AttributeHandlerT):
+	def __init__(self, attribute: AttributeT, func: AttributeHandlerFuncT):
 		super().__init__(func)
 		self._attribute = attribute
 
@@ -140,7 +128,7 @@ class AttributeHandler[
 		return self._func(protocolHandler, *args, **kwargs)
 
 
-class AttributeSender(AttributeHandler[attributeFetcherT]):
+class AttributeSender(AttributeHandler[AttributeFetcherT]):
 	def __call__(
 		self,
 		protocolHandler: RemoteProtocolHandler,
@@ -156,15 +144,15 @@ def attributeSender(attribute: AttributeT):
 	return partial(AttributeSender, attribute)
 
 
-class AttributeReceiver(AttributeHandler[AttributeReceiverUnboundT | WildCardAttributeReceiverUnboundT]):
-	_defaultValueGetter: DefaultValueGetterT | None
+class AttributeReceiver(AttributeHandler[AttributeReceiverFuncT]):
+	_defaultValueGetter: DefaultValueGetterT
 	_updateCallback: AttributeValueUpdateCallbackT | None
 
 	def __init__(
 		self,
 		attribute: AttributeT,
-		func: AttributeReceiverUnboundT | WildCardAttributeReceiverUnboundT,
-		defaultValueGetter: DefaultValueGetterT | None,
+		func: AttributeReceiverFuncT,
+		defaultValueGetter: DefaultValueGetterT,
 		updateCallback: AttributeValueUpdateCallbackT | None,
 	):
 		super().__init__(attribute, func)
@@ -205,71 +193,60 @@ def attributeReceiver(
 	)
 
 
-class CommandHandlerStore(HandlerRegistrar):
-	_commandIndex: dict[CommandT, CommandHandlerT]
+class HandlerStoreBase:
+	"""Base for the per-instance handler registries on a RemoteProtocolHandler.
 
-	def __init__(self, *, _deprecationMessage: str | None = None):
-		super().__init__(_deprecationMessage=_deprecationMessage)
+	A store holds the class-level handler descriptors and a weak reference to its owning
+	protocol handler, which is passed to the descriptors explicitly on dispatch.
+	The reference is weak so a registry never keeps its owner alive.
+	"""
+
+	_owner: weakref.ref[RemoteProtocolHandler]
+
+	def __init__(self, owner: RemoteProtocolHandler):
+		self._owner = weakref.ref(owner)
+
+	def _getOwner(self) -> RemoteProtocolHandler:
+		owner = self._owner()
+		if owner is None:
+			raise NotImplementedError("The protocol handler that owns this store no longer exists")
+		return owner
+
+
+class CommandHandlerStore(HandlerStoreBase):
+	_commandIndex: dict[CommandT, CommandHandler]
+
+	def __init__(self, owner: RemoteProtocolHandler):
+		super().__init__(owner)
 		self._commandIndex = {}
 
-	def register(self, handler: CommandHandlerT):
-		super().register(handler)
-		# Registered handlers are bound methods that forward _command to the descriptor. See #59.
-		self._commandIndex[handler._command] = handler  # ty: ignore[unresolved-attribute]
-
-	def unregister(self, handler):
-		result = super().unregister(handler)
-		if result:
-			# handler may be a weakref wrapper at this point; rebuild index from live handlers.
-			self._commandIndex = {h._command: h for h in self.handlers}
-		return result
-
-	def _getHandler(self, command: CommandT) -> CommandHandlerT:
-		handler = self._commandIndex.get(command)
-		if handler is None:
-			raise NotImplementedError(f"No command handler for command {command!r}")
-		return handler
+	def register(self, handler: CommandHandler):
+		self._commandIndex[handler._command] = handler
 
 	def __call__(self, command: CommandT, payload: bytes):
 		log.debug(f"Getting handler on {self!r} to process command {command!r}")
-		handler = self._getHandler(command)
-		handler(payload)
+		handler = self._commandIndex.get(command)
+		if handler is None:
+			raise NotImplementedError(f"No command handler for command {command!r}")
+		handler(self._getOwner(), payload)
 
 
-class AttributeHandlerStore[
-	AttributeHandlerT: (attributeFetcherT, AttributeReceiverUnboundT, WildCardAttributeReceiverUnboundT),
-](HandlerRegistrar[AttributeHandler]):
-	_exactIndex: dict[AttributeT, AttributeHandler]
-	_wildcardHandlers: list[AttributeHandler]
+class AttributeHandlerStore[AttributeHandlerT: AttributeHandler](HandlerStoreBase):
+	_exactIndex: dict[AttributeT, AttributeHandlerT]
+	_wildcardHandlers: list[AttributeHandlerT]
 
-	def __init__(self, *, _deprecationMessage: str | None = None):
-		super().__init__(_deprecationMessage=_deprecationMessage)
+	def __init__(self, owner: RemoteProtocolHandler):
+		super().__init__(owner)
 		self._exactIndex = {}
 		self._wildcardHandlers = []
 
-	def _rebuildIndex(self):
-		self._exactIndex = {}
-		self._wildcardHandlers = []
-		for h in self.handlers:
-			if h._isCatchAll:
-				self._wildcardHandlers.append(h)
-			else:
-				self._exactIndex[h._attribute] = h
-
-	def register(self, handler: AttributeHandler):
-		super().register(handler)
+	def register(self, handler: AttributeHandlerT):
 		if handler._isCatchAll:
 			self._wildcardHandlers.append(handler)
 		else:
 			self._exactIndex[handler._attribute] = handler
 
-	def unregister(self, handler):
-		result = super().unregister(handler)
-		if result:
-			self._rebuildIndex()
-		return result
-
-	def _getRawHandler(self, attribute: AttributeT) -> AttributeHandler:
+	def _getRawHandler(self, attribute: AttributeT) -> AttributeHandlerT:
 		# Exact match takes priority over wildcard patterns (e.g. a specific attribute beats setting_*)
 		handler = self._exactIndex.get(attribute)
 		if handler is not None:
@@ -279,24 +256,19 @@ class AttributeHandlerStore[
 			raise NotImplementedError(f"No attribute sender for attribute {attribute}")
 		return handler
 
-	def _getHandler(self, attribute: AttributeT) -> AttributeHandlerT:
-		# partial-binding the attribute onto the bound handler defeats ty's arg analysis. See #59.
-		boundHandler = partial(self._getRawHandler(attribute), attribute)  # ty: ignore[invalid-argument-type]
-		return cast(AttributeHandlerT, boundHandler)
-
 	def isAttributeSupported(self, attribute: AttributeT):
 		try:
-			self._getHandler(attribute)
+			self._getRawHandler(attribute)
 			return True
 		except NotImplementedError:
 			return False
 
 
-class AttributeSenderStore(AttributeHandlerStore[attributeSenderT]):
+class AttributeSenderStore(AttributeHandlerStore[AttributeSender]):
 	def __call__(self, attribute: AttributeT, *args, **kwargs):
 		log.debug(f"Getting handler on {self!r} to process attribute {attribute!r}")
-		handler = self._getHandler(attribute)
-		handler(*args, **kwargs)
+		handler = self._getRawHandler(attribute)
+		handler(self._getOwner(), attribute, *args, **kwargs)
 
 
 class AttributeValueProcessor(AttributeHandlerStore[AttributeReceiver]):
@@ -304,8 +276,8 @@ class AttributeValueProcessor(AttributeHandlerStore[AttributeReceiver]):
 	_values: dict[AttributeT, Any]
 	_pendingAttributeRequests: defaultdict[AttributeT, bool]
 
-	def __init__(self):
-		super().__init__()
+	def __init__(self, owner: RemoteProtocolHandler):
+		super().__init__(owner)
 		self._values = {}
 		self._valueTimes = defaultdict(float)
 		self._pendingAttributeRequests = defaultdict(bool)
@@ -326,23 +298,19 @@ class AttributeValueProcessor(AttributeHandlerStore[AttributeReceiver]):
 		return t <= self._valueTimes[attribute]
 
 	def _getDefaultAttributeValue(self, attribute: AttributeT) -> Any:
-		# handler is a bound method that forwards _defaultValueGetter/__self__ to its
-		# AttributeReceiver descriptor; ty can't model this forwarding. See #59.
 		handler = self._getRawHandler(attribute)
 		log.debug(
 			f"Getting default value for attribute {attribute!r} on {self!r} "
-			f"using {handler._defaultValueGetter!r}",  # ty: ignore[unresolved-attribute]
+			f"using {handler._defaultValueGetter!r}",
 		)
-		getter = handler._defaultValueGetter.__get__(handler.__self__)  # ty: ignore[unresolved-attribute]
-		return getter(attribute)
+		return handler._defaultValueGetter(self._getOwner(), attribute)
 
 	def _submitAttributeUpdateCallback(self, attribute: AttributeT, value: Any):
-		# See #59: bound-method attribute forwarding is invisible to ty.
 		handler = self._getRawHandler(attribute)
-		if handler._updateCallback is not None:  # ty: ignore[unresolved-attribute]
-			callback = handler._updateCallback.__get__(handler.__self__)  # ty: ignore[unresolved-attribute]
-			log.debug(f"Calling update callback {callback!r} for attribute {attribute!r}")
-			handler.__self__._bgExecutor.submit(callback, attribute, value)  # ty: ignore[unresolved-attribute]
+		if handler._updateCallback is not None:
+			log.debug(f"Calling update callback {handler._updateCallback!r} for attribute {attribute!r}")
+			owner = self._getOwner()
+			owner._bgExecutor.submit(handler._updateCallback, owner, attribute, value)
 
 	def getValue(self, attribute: AttributeT, fallBackToDefault: bool = False):
 		if fallBackToDefault and attribute not in self._values:
@@ -360,15 +328,11 @@ class AttributeValueProcessor(AttributeHandlerStore[AttributeReceiver]):
 
 	def __call__(self, attribute: AttributeT, rawValue: bytes):
 		log.debug(f"Getting handler on {self!r} to process attribute {attribute!r}")
-		handler = self._getHandler(attribute)
-		# handler is a partial that has already bound `attribute`; ty sees the unbound sig. See #59.
-		value = handler(rawValue)  # ty: ignore[missing-argument, invalid-argument-type]
+		handler = self._getRawHandler(attribute)
+		value = handler(self._getOwner(), attribute, rawValue)
 		log.debug(f"Handler on {self!r} returned value {value!r} for attribute {attribute!r}")
 		self.setAttributeRequestPending(attribute, False)
 		self.setValue(attribute, value)
-
-
-IoTypeT = TypeVar("IoTypeT", bound=IoBase)
 
 
 class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
@@ -384,17 +348,17 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 
 	def __new__(cls, *args, **kwargs):
 		self = super().__new__(cls, *args, **kwargs)
-		self._commandHandlerStore = CommandHandlerStore()
-		self._attributeSenderStore = AttributeSenderStore()
-		self._attributeValueProcessor = AttributeValueProcessor()
+		self._commandHandlerStore = CommandHandlerStore(self)
+		self._attributeSenderStore = AttributeSenderStore(self)
+		self._attributeValueProcessor = AttributeValueProcessor(self)
 		handlers = inspect.getmembers(cls, predicate=lambda o: isinstance(o, HandlerDecoratorBase))
-		for k, v in handlers:
-			if isinstance(v, CommandHandler):
-				self._commandHandlerStore.register(getattr(self, k))
-			elif isinstance(v, AttributeSender):
-				self._attributeSenderStore.register(getattr(self, k))
-			elif isinstance(v, AttributeReceiver):
-				self._attributeValueProcessor.register(getattr(self, k))
+		for _name, handler in handlers:
+			if isinstance(handler, CommandHandler):
+				self._commandHandlerStore.register(handler)
+			elif isinstance(handler, AttributeSender):
+				self._attributeSenderStore.register(handler)
+			elif isinstance(handler, AttributeReceiver):
+				self._attributeValueProcessor.register(handler)
 		return self
 
 	def terminateIo(self):

--- a/prek.toml
+++ b/prek.toml
@@ -106,5 +106,13 @@ hooks = [
     language = "system",
     types = ["python"],
     pass_filenames = false
+  },
+  {
+    id = "unittest",
+    name = "run unit tests",
+    entry = "uv run python -m unittest discover -s tests -t .",
+    language = "system",
+    types = ["python"],
+    pass_filenames = false
   }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,9 @@ select = [
 # sconscripts contains many inbuilt functions not recognised by the lint,
 # so ignore F821.
 "sconstruct" = ["F821"]
+# Test doubles must match the signatures of the NVDA APIs they stand in for,
+# so unused arguments are expected.
+"tests/**" = ["ARG002"]
 
 [tool.ty.environment]
 python-version = "3.13"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,35 @@
+# RDAccess: Remote Desktop Accessibility for NVDA
+# Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
+# License: GNU General Public License version 2.0
+
+"""Unit test package bootstrap.
+
+Importing this package prepares an environment in which ``addon/lib/protocol``
+can be imported without a running NVDA instance:
+
+* ``addon`` is put on ``sys.path`` so the protocol package resolves as ``lib.protocol``.
+* The sibling NVDA source checkout (``../nvda/source``) is put on ``sys.path`` so the
+  real ``baseObject`` and ``extensionPoints`` modules are used.
+* Light-weight stand-ins for NVDA runtime modules are installed into ``sys.modules``
+  (see :mod:`tests._stubs`) before anything imports them.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_NVDA_SOURCE = (_REPO_ROOT.parent / "nvda" / "source").resolve()
+if not (_NVDA_SOURCE / "baseObject.py").is_file():
+	raise RuntimeError(
+		"The unit tests require an NVDA source checkout in a directory next to this repository. "
+		f"Expected to find {_NVDA_SOURCE / 'baseObject.py'}. "
+		"Clone https://github.com/nvaccess/nvda.git as a sibling of this repository.",
+	)
+sys.path.insert(0, str(_NVDA_SOURCE))
+sys.path.insert(0, str(_REPO_ROOT / "addon"))
+
+from . import _stubs  # noqa: E402
+
+_stubs.install()

--- a/tests/_fakes.py
+++ b/tests/_fakes.py
@@ -1,0 +1,88 @@
+# RDAccess: Remote Desktop Accessibility for NVDA
+# Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
+# License: GNU General Public License version 2.0
+
+"""Test doubles for exercising ``lib.protocol`` without NVDA or a real pipe."""
+
+from __future__ import annotations
+
+import sys
+from concurrent.futures import Future
+from typing import Any
+
+from hwIo.base import IoBase
+from lib import protocol
+
+
+class FakeIo(IoBase):
+	"""Captures written messages and serves scripted waitForRead results."""
+
+	def __init__(self):
+		self.writes: list[bytes] = []
+		self.waitForReadResults: list[bool] = []
+		self.closed = False
+
+	def write(self, data: bytes):
+		self.writes.append(data)
+
+	def waitForRead(self, timeout: float) -> bool:
+		if self.waitForReadResults:
+			return self.waitForReadResults.pop(0)
+		return False
+
+	def close(self):
+		self.closed = True
+
+
+class InlineExecutor:
+	"""Drop-in for the handler's ThreadPoolExecutor that runs submissions synchronously.
+
+	Exceptions are captured on the returned future, mirroring how a real executor
+	swallows them when the future is discarded.
+	"""
+
+	def __init__(self):
+		self.isShutdown = False
+
+	def submit(self, fn: Any, *args: Any, **kwargs: Any) -> Future:
+		future: Future = Future()
+		try:
+			future.set_result(fn(*args, **kwargs))
+		except BaseException as e:  # noqa: BLE001
+			future.set_exception(e)
+		return future
+
+	def shutdown(self, wait: bool = True, *, cancel_futures: bool = False):
+		self.isShutdown = True
+
+
+class FakeHandlerBase(protocol.RemoteProtocolHandler):
+	"""Concrete RemoteProtocolHandler attached to a FakeIo device.
+
+	Background execution is synchronous (InlineExecutor), so command dispatch and
+	attribute processing triggered through _onReceive complete before it returns.
+	"""
+
+	driverType = protocol.DriverType.SPEECH
+
+	def __init__(self):
+		super().__init__()
+		self._bgExecutor.shutdown(wait=False)
+		self._bgExecutor = InlineExecutor()
+		self._dev = FakeIo()
+
+	def _onReadError(self, error: int) -> bool:
+		return False
+
+	def _incoming_setting(self, attribute: protocol.AttributeT, payLoad: bytes):
+		raise NotImplementedError
+
+
+def buildMessage(driverType: int, command: int, payload: bytes = b"") -> bytes:
+	"""Construct a wire message as the remote end would send it."""
+	return bytes((
+		driverType,
+		command,
+		*len(payload).to_bytes(length=2, byteorder=sys.byteorder, signed=False),
+		*payload,
+	))

--- a/tests/_stubs.py
+++ b/tests/_stubs.py
@@ -1,0 +1,147 @@
+# RDAccess: Remote Desktop Accessibility for NVDA
+# Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
+# License: GNU General Public License version 2.0
+
+"""Stand-ins for NVDA runtime modules, installed into ``sys.modules``.
+
+Only leaf modules are stubbed. ``baseObject`` and ``extensionPoints`` are imported
+for real from the sibling NVDA source checkout; their dependencies (``logHandler``,
+``garbageHandler``, ``NVDAState``) are covered here.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+
+class FakeLogger:
+	"""Collects log records so tests can optionally assert on them."""
+
+	def __init__(self):
+		self.records: list[tuple[str, str]] = []
+
+	def _log(self, level: str, msg: Any, *args: Any, **kwargs: Any):
+		self.records.append((level, str(msg)))
+
+	def debug(self, msg: Any, *args: Any, **kwargs: Any):
+		self._log("debug", msg)
+
+	def debugWarning(self, msg: Any, *args: Any, **kwargs: Any):
+		self._log("debugWarning", msg)
+
+	def info(self, msg: Any, *args: Any, **kwargs: Any):
+		self._log("info", msg)
+
+	def warning(self, msg: Any, *args: Any, **kwargs: Any):
+		self._log("warning", msg)
+
+	def error(self, msg: Any, *args: Any, **kwargs: Any):
+		self._log("error", msg)
+
+	def exception(self, msg: Any, *args: Any, **kwargs: Any):
+		self._log("exception", msg)
+
+	def critical(self, msg: Any, *args: Any, **kwargs: Any):
+		self._log("critical", msg)
+
+
+def _module(name: str) -> types.ModuleType:
+	mod = types.ModuleType(name)
+	sys.modules[name] = mod
+	return mod
+
+
+def install():
+	"""Install all stub modules. Idempotent; must run before importing ``lib.protocol``."""
+	if "logHandler" in sys.modules:
+		return
+
+	logHandler = _module("logHandler")
+	logHandler.log = FakeLogger()
+
+	garbageHandler = _module("garbageHandler")
+
+	class TrackedObject:
+		"""Unlike the real one, defines no __del__, keeping garbage collection in tests silent."""
+
+	garbageHandler.TrackedObject = TrackedObject
+
+	NVDAState = _module("NVDAState")
+
+	def _allowDeprecatedAPI() -> bool:
+		return False
+
+	NVDAState._allowDeprecatedAPI = _allowDeprecatedAPI
+
+	addonHandler = _module("addonHandler")
+
+	class Addon:
+		version = "0.0-test"
+		name = "rdAccessTest"
+
+	def getCodeAddon() -> Addon:
+		return Addon()
+
+	addonHandler.Addon = Addon
+	addonHandler.getCodeAddon = getCodeAddon
+
+	queueHandler = _module("queueHandler")
+	queueHandler.eventQueue = object()
+	queuedFunctions: list[tuple[Any, Any, tuple, dict]] = []
+
+	def queueFunction(queue: Any, func: Any, *args: Any, **kwargs: Any):
+		queuedFunctions.append((queue, func, args, kwargs))
+
+	def pumpAll():
+		"""Execute and drain everything queued through queueFunction."""
+		while queuedFunctions:
+			_queue, func, args, kwargs = queuedFunctions.pop(0)
+			func(*args, **kwargs)
+
+	queueHandler.queuedFunctions = queuedFunctions
+	queueHandler.queueFunction = queueFunction
+	queueHandler.pumpAll = pumpAll
+
+	versionInfo = _module("versionInfo")
+	versionInfo.version_detailed = "2026.1.0-test"
+
+	hwIo = _module("hwIo")
+	hwIoBase = _module("hwIo.base")
+	hwIo.base = hwIoBase
+
+	class IoBase:
+		def write(self, data: bytes):
+			raise NotImplementedError
+
+		def waitForRead(self, timeout: float) -> bool:
+			raise NotImplementedError
+
+		def close(self):
+			pass
+
+	hwIoBase.IoBase = IoBase
+
+	braille = _module("braille")
+
+	class BrailleDisplayGesture:
+		pass
+
+	braille.BrailleDisplayGesture = BrailleDisplayGesture
+
+	brailleInput = _module("brailleInput")
+
+	class BrailleInputGesture:
+		pass
+
+	brailleInput.BrailleInputGesture = BrailleInputGesture
+
+	speech = _module("speech")
+	speechManager = _module("speech.manager")
+	speech.manager = speechManager
+
+	class SpeechManager:
+		MAX_INDEX = 9999
+
+	speechManager.SpeechManager = SpeechManager

--- a/tests/test_attributeHandling.py
+++ b/tests/test_attributeHandling.py
@@ -1,0 +1,545 @@
+# RDAccess: Remote Desktop Accessibility for NVDA
+# Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
+# License: GNU General Public License version 2.0
+
+"""Unit tests for attribute sender/receiver machinery in lib.protocol."""
+
+from __future__ import annotations
+
+import time
+import unittest
+
+from lib import protocol
+
+from tests._fakes import FakeHandlerBase, buildMessage
+
+# ---------------------------------------------------------------------------
+# Helper: build a raw ATTRIBUTE payload as the wire expects it.
+# ---------------------------------------------------------------------------
+
+
+def _attrPayload(attribute: bytes, value: bytes = b"") -> bytes:
+	"""Return the payload bytes that _command_attribute parses."""
+	return protocol.ATTRIBUTE_SEPARATOR + attribute + protocol.ATTRIBUTE_SEPARATOR + value
+
+
+# ---------------------------------------------------------------------------
+# 1. Request path: sender store produces a reply write.
+# ---------------------------------------------------------------------------
+
+
+class LanguageSender(FakeHandlerBase):
+	@protocol.attributeSender(protocol.SpeechAttribute.LANGUAGE)
+	def _outgoing_language(self) -> bytes:
+		return b"nl"
+
+
+class TestRequestPath(unittest.TestCase):
+	def setUp(self):
+		self.handler = LanguageSender()
+		self.addCleanup(self.handler.terminate)
+
+	def test_request_triggers_reply_write(self):
+		"""Empty-value ATTRIBUTE message causes setRemoteAttribute to be called."""
+		msg = buildMessage(
+			protocol.DriverType.SPEECH,
+			protocol.GenericCommand.ATTRIBUTE,
+			_attrPayload(protocol.SpeechAttribute.LANGUAGE),
+		)
+		self.handler._onReceive(msg)
+		self.assertEqual(len(self.handler._dev.writes), 1)
+
+	def test_reply_payload_contains_attribute_and_value(self):
+		"""The written reply embeds ``language`` and ``nl`` in its payload."""
+		msg = buildMessage(
+			protocol.DriverType.SPEECH,
+			protocol.GenericCommand.ATTRIBUTE,
+			_attrPayload(protocol.SpeechAttribute.LANGUAGE),
+		)
+		self.handler._onReceive(msg)
+		written = self.handler._dev.writes[0]
+		expected_payload = _attrPayload(protocol.SpeechAttribute.LANGUAGE, b"nl")
+		# The written message is a full wire message; the payload starts at byte 4.
+		self.assertIn(expected_payload, written)
+
+
+# ---------------------------------------------------------------------------
+# 2. Push path: value processor stores the decoded value.
+# ---------------------------------------------------------------------------
+
+
+class LanguageReceiver(FakeHandlerBase):
+	@protocol.attributeReceiver(protocol.SpeechAttribute.LANGUAGE, defaultValue="en")
+	def _incoming_language(self, payload: bytes) -> str:
+		return payload.decode()
+
+
+class TestPushPath(unittest.TestCase):
+	def setUp(self):
+		self.handler = LanguageReceiver()
+		self.addCleanup(self.handler.terminate)
+
+	def test_push_stores_decoded_value(self):
+		msg = buildMessage(
+			protocol.DriverType.SPEECH,
+			protocol.GenericCommand.ATTRIBUTE,
+			_attrPayload(protocol.SpeechAttribute.LANGUAGE, b"nl"),
+		)
+		self.handler._onReceive(msg)
+		value = self.handler._attributeValueProcessor.getValue(
+			protocol.SpeechAttribute.LANGUAGE,
+			fallBackToDefault=False,
+		)
+		self.assertEqual(value, "nl")
+
+	def test_push_no_writes(self):
+		"""An incoming push must not generate a reply write."""
+		msg = buildMessage(
+			protocol.DriverType.SPEECH,
+			protocol.GenericCommand.ATTRIBUTE,
+			_attrPayload(protocol.SpeechAttribute.LANGUAGE, b"nl"),
+		)
+		self.handler._onReceive(msg)
+		self.assertEqual(self.handler._dev.writes, [])
+
+
+# ---------------------------------------------------------------------------
+# 3. updateCallback fires when a value is pushed.
+# ---------------------------------------------------------------------------
+
+
+class LanguageReceiverWithCallback(FakeHandlerBase):
+	def __init__(self):
+		self.callback_calls: list[tuple[protocol.AttributeT, object]] = []
+		super().__init__()
+
+	@protocol.attributeReceiver(protocol.SpeechAttribute.LANGUAGE, defaultValue="en")
+	def _incoming_language(self, payload: bytes) -> str:
+		return payload.decode()
+
+	@_incoming_language.updateCallback
+	def _cb_language(self, attribute: protocol.AttributeT, value: object) -> None:
+		self.callback_calls.append((attribute, value))
+
+
+class TestUpdateCallback(unittest.TestCase):
+	def setUp(self):
+		self.handler = LanguageReceiverWithCallback()
+		self.addCleanup(self.handler.terminate)
+
+	def test_callback_fires_on_push(self):
+		msg = buildMessage(
+			protocol.DriverType.SPEECH,
+			protocol.GenericCommand.ATTRIBUTE,
+			_attrPayload(protocol.SpeechAttribute.LANGUAGE, b"nl"),
+		)
+		self.handler._onReceive(msg)
+		self.assertEqual(len(self.handler.callback_calls), 1)
+		attr, val = self.handler.callback_calls[0]
+		self.assertEqual(attr, protocol.SpeechAttribute.LANGUAGE)
+		self.assertEqual(val, "nl")
+
+	def test_callback_fires_on_setValue(self):
+		self.handler._attributeValueProcessor.setValue(protocol.SpeechAttribute.LANGUAGE, "de")
+		self.assertEqual(len(self.handler.callback_calls), 1)
+		attr, val = self.handler.callback_calls[0]
+		self.assertEqual(attr, protocol.SpeechAttribute.LANGUAGE)
+		self.assertEqual(val, "de")
+
+	def test_callback_records_correct_value_inside_body(self):
+		"""Callback body sees exactly the value that was pushed, not stale state."""
+		msg = buildMessage(
+			protocol.DriverType.SPEECH,
+			protocol.GenericCommand.ATTRIBUTE,
+			_attrPayload(protocol.SpeechAttribute.LANGUAGE, b"fr"),
+		)
+		self.handler._onReceive(msg)
+		self.assertEqual(self.handler.callback_calls[-1], (protocol.SpeechAttribute.LANGUAGE, "fr"))
+
+
+# ---------------------------------------------------------------------------
+# 4. defaultValue: _getDefaultAttributeValue and getValue fallback.
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultValue(unittest.TestCase):
+	def setUp(self):
+		self.handler = LanguageReceiver()
+		self.addCleanup(self.handler.terminate)
+
+	def test_getDefaultAttributeValue_returns_declared_default(self):
+		val = self.handler._attributeValueProcessor._getDefaultAttributeValue(
+			protocol.SpeechAttribute.LANGUAGE,
+		)
+		self.assertEqual(val, "en")
+
+	def test_getValue_fallback_returns_default(self):
+		val = self.handler._attributeValueProcessor.getValue(
+			protocol.SpeechAttribute.LANGUAGE,
+			fallBackToDefault=True,
+		)
+		self.assertEqual(val, "en")
+
+	def test_getValue_fallback_caches_default(self):
+		"""After a fallback getValue, a non-fallback getValue must succeed."""
+		self.handler._attributeValueProcessor.getValue(
+			protocol.SpeechAttribute.LANGUAGE,
+			fallBackToDefault=True,
+		)
+		val = self.handler._attributeValueProcessor.getValue(
+			protocol.SpeechAttribute.LANGUAGE,
+			fallBackToDefault=False,
+		)
+		self.assertEqual(val, "en")
+
+	def test_getValue_no_fallback_raises_before_any_push(self):
+		with self.assertRaises(KeyError):
+			self.handler._attributeValueProcessor.getValue(
+				protocol.SpeechAttribute.LANGUAGE,
+				fallBackToDefault=False,
+			)
+
+
+# ---------------------------------------------------------------------------
+# 5. defaultValueGetter: custom callable overrides the static defaultValue.
+# ---------------------------------------------------------------------------
+
+_SENTINEL = object()
+
+
+class LanguageReceiverWithGetter(FakeHandlerBase):
+	@protocol.attributeReceiver(protocol.SpeechAttribute.LANGUAGE)
+	def _incoming_language(self, payload: bytes) -> object:
+		return payload.decode()
+
+	@_incoming_language.defaultValueGetter
+	def _default_language(self, _attribute: protocol.AttributeT) -> object:
+		return _SENTINEL
+
+
+class TestDefaultValueGetter(unittest.TestCase):
+	def setUp(self):
+		self.handler = LanguageReceiverWithGetter()
+		self.addCleanup(self.handler.terminate)
+
+	def test_defaultValueGetter_returns_sentinel(self):
+		val = self.handler._attributeValueProcessor.getValue(
+			protocol.SpeechAttribute.LANGUAGE,
+			fallBackToDefault=True,
+		)
+		self.assertIs(val, _SENTINEL)
+
+
+# ---------------------------------------------------------------------------
+# 6. Factory validation: both defaultValue and defaultValueGetter → ValueError.
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryValidation(unittest.TestCase):
+	def test_both_defaultValue_and_defaultValueGetter_raises(self):
+		with self.assertRaises(ValueError):
+			protocol.attributeReceiver(b"x", defaultValue=1, defaultValueGetter=lambda _s, _a: 2)
+
+
+# ---------------------------------------------------------------------------
+# 7. Wildcard receiver: catch-all receives concrete attribute as first arg.
+# ---------------------------------------------------------------------------
+
+
+class WildcardSettingReceiver(FakeHandlerBase):
+	def __init__(self):
+		self.wildcard_calls: list[tuple[bytes, bytes]] = []
+		super().__init__()
+
+	@protocol.attributeReceiver(protocol.SETTING_ATTRIBUTE_PREFIX + b"*")
+	def _incoming_setting(self, attribute: protocol.AttributeT, payload: bytes) -> bytes:  # type: ignore[override]
+		self.wildcard_calls.append((bytes(attribute), payload))
+		return payload
+
+
+class TestWildcardReceiver(unittest.TestCase):
+	def setUp(self):
+		self.handler = WildcardSettingReceiver()
+		self.addCleanup(self.handler.terminate)
+
+	def test_wildcard_invoked_with_concrete_attribute(self):
+		msg = buildMessage(
+			protocol.DriverType.SPEECH,
+			protocol.GenericCommand.ATTRIBUTE,
+			_attrPayload(b"setting_rate", b"50"),
+		)
+		self.handler._onReceive(msg)
+		self.assertEqual(len(self.handler.wildcard_calls), 1)
+		attr, payload = self.handler.wildcard_calls[0]
+		self.assertEqual(attr, b"setting_rate")
+		self.assertEqual(payload, b"50")
+
+	def test_value_stored_under_concrete_attribute(self):
+		msg = buildMessage(
+			protocol.DriverType.SPEECH,
+			protocol.GenericCommand.ATTRIBUTE,
+			_attrPayload(b"setting_rate", b"50"),
+		)
+		self.handler._onReceive(msg)
+		val = self.handler._attributeValueProcessor.getValue(b"setting_rate", fallBackToDefault=False)
+		self.assertEqual(val, b"50")
+
+
+# ---------------------------------------------------------------------------
+# 8. Exact beats wildcard for setting_voice.
+# ---------------------------------------------------------------------------
+
+
+class ExactBeatWildcardReceiver(FakeHandlerBase):
+	def __init__(self):
+		self.wildcard_calls: list[tuple[bytes, bytes]] = []
+		self.exact_calls: list[bytes] = []
+		super().__init__()
+
+	@protocol.attributeReceiver(protocol.SETTING_ATTRIBUTE_PREFIX + b"*")
+	def _incoming_setting(self, attribute: protocol.AttributeT, payload: bytes) -> bytes:  # type: ignore[override]
+		self.wildcard_calls.append((bytes(attribute), payload))
+		return payload
+
+	@protocol.attributeReceiver(b"setting_voice", defaultValue=None)
+	def _incoming_setting_voice(self, payload: bytes) -> bytes:
+		self.exact_calls.append(payload)
+		return payload
+
+
+class TestExactBeatsWildcard(unittest.TestCase):
+	def setUp(self):
+		self.handler = ExactBeatWildcardReceiver()
+		self.addCleanup(self.handler.terminate)
+
+	def test_exact_handler_invoked_for_setting_voice(self):
+		msg = buildMessage(
+			protocol.DriverType.SPEECH,
+			protocol.GenericCommand.ATTRIBUTE,
+			_attrPayload(b"setting_voice", b"David"),
+		)
+		self.handler._onReceive(msg)
+		self.assertEqual(self.handler.exact_calls, [b"David"])
+
+	def test_wildcard_not_invoked_for_setting_voice(self):
+		msg = buildMessage(
+			protocol.DriverType.SPEECH,
+			protocol.GenericCommand.ATTRIBUTE,
+			_attrPayload(b"setting_voice", b"David"),
+		)
+		self.handler._onReceive(msg)
+		self.assertEqual(self.handler.wildcard_calls, [])
+
+	def test_wildcard_still_handles_other_settings(self):
+		msg = buildMessage(
+			protocol.DriverType.SPEECH,
+			protocol.GenericCommand.ATTRIBUTE,
+			_attrPayload(b"setting_rate", b"75"),
+		)
+		self.handler._onReceive(msg)
+		self.assertEqual(len(self.handler.wildcard_calls), 1)
+		self.assertEqual(self.handler.exact_calls, [])
+
+
+# ---------------------------------------------------------------------------
+# 9. Wildcard sender: function receives concrete attribute.
+# ---------------------------------------------------------------------------
+
+
+class WildcardSenderHandler(FakeHandlerBase):
+	def __init__(self):
+		self.sender_calls: list[bytes] = []
+		super().__init__()
+
+	@protocol.attributeSender(b"available*s")
+	def _outgoing_available(self, attribute: protocol.AttributeT) -> bytes:
+		self.sender_calls.append(bytes(attribute))
+		return b"data_for_" + bytes(attribute)
+
+
+class TestWildcardSender(unittest.TestCase):
+	def setUp(self):
+		self.handler = WildcardSenderHandler()
+		self.addCleanup(self.handler.terminate)
+
+	def test_wildcard_sender_writes_reply(self):
+		self.handler._attributeSenderStore(b"availableVoices")
+		self.assertEqual(len(self.handler._dev.writes), 1)
+
+	def test_wildcard_sender_receives_concrete_attribute(self):
+		self.handler._attributeSenderStore(b"availableVoices")
+		self.assertEqual(self.handler.sender_calls, [b"availableVoices"])
+
+	def test_wildcard_sender_reply_contains_concrete_attribute(self):
+		self.handler._attributeSenderStore(b"availableVoices")
+		written = self.handler._dev.writes[0]
+		self.assertIn(b"availableVoices", written)
+
+	def test_wildcard_sender_reply_contains_value(self):
+		self.handler._attributeSenderStore(b"availableVoices")
+		written = self.handler._dev.writes[0]
+		self.assertIn(b"data_for_availableVoices", written)
+
+
+# ---------------------------------------------------------------------------
+# 10. isAttributeSupported.
+# ---------------------------------------------------------------------------
+
+
+class TestIsAttributeSupported(unittest.TestCase):
+	def setUp(self):
+		self.handler = LanguageSender()
+		self.addCleanup(self.handler.terminate)
+		self.receiver_handler = LanguageReceiver()
+		self.addCleanup(self.receiver_handler.terminate)
+
+	def test_exact_sender_supported(self):
+		self.assertTrue(
+			self.handler._attributeSenderStore.isAttributeSupported(protocol.SpeechAttribute.LANGUAGE),
+		)
+
+	def test_unknown_sender_not_supported(self):
+		self.assertFalse(
+			self.handler._attributeSenderStore.isAttributeSupported(b"unknownAttribute"),
+		)
+
+	def test_exact_receiver_supported(self):
+		self.assertTrue(
+			self.receiver_handler._attributeValueProcessor.isAttributeSupported(
+				protocol.SpeechAttribute.LANGUAGE,
+			),
+		)
+
+	def test_unknown_receiver_not_supported(self):
+		self.assertFalse(
+			self.receiver_handler._attributeValueProcessor.isAttributeSupported(b"unknownAttribute"),
+		)
+
+	def test_wildcard_receiver_matched_supported(self):
+		handler = WildcardSettingReceiver()
+		self.addCleanup(handler.terminate)
+		self.assertTrue(
+			handler._attributeValueProcessor.isAttributeSupported(b"setting_pitch"),
+		)
+
+
+# ---------------------------------------------------------------------------
+# 11. Unknown attribute dispatch raises NotImplementedError.
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownAttributeDispatch(unittest.TestCase):
+	def setUp(self):
+		self.handler = LanguageReceiver()
+		self.addCleanup(self.handler.terminate)
+
+	def test_unknown_receiver_raises(self):
+		with self.assertRaises(NotImplementedError):
+			self.handler._attributeValueProcessor(b"nope", b"v")
+
+	def test_unknown_sender_raises(self):
+		with self.assertRaises(NotImplementedError):
+			self.handler._attributeSenderStore(b"nope")
+
+
+# ---------------------------------------------------------------------------
+# 12. hasNewValueSince.
+# ---------------------------------------------------------------------------
+
+
+class TestHasNewValueSince(unittest.TestCase):
+	def setUp(self):
+		self.handler = LanguageReceiver()
+		self.addCleanup(self.handler.terminate)
+
+	def test_has_new_value_after_setValue(self):
+		t = time.perf_counter()
+		self.handler._attributeValueProcessor.setValue(protocol.SpeechAttribute.LANGUAGE, "nl")
+		self.assertTrue(
+			self.handler._attributeValueProcessor.hasNewValueSince(
+				protocol.SpeechAttribute.LANGUAGE,
+				t,
+			),
+		)
+
+	def test_no_new_value_for_never_set_attribute(self):
+		t = time.perf_counter()
+		self.assertFalse(
+			self.handler._attributeValueProcessor.hasNewValueSince(
+				protocol.SpeechAttribute.LANGUAGE,
+				t,
+			),
+		)
+
+
+# ---------------------------------------------------------------------------
+# 13. clearValue and clearCache.
+# ---------------------------------------------------------------------------
+
+
+class TestClearValueAndCache(unittest.TestCase):
+	def setUp(self):
+		self.handler = LanguageReceiver()
+		self.addCleanup(self.handler.terminate)
+
+	def test_clearValue_then_getValue_raises_KeyError(self):
+		self.handler._attributeValueProcessor.setValue(protocol.SpeechAttribute.LANGUAGE, "nl")
+		self.handler._attributeValueProcessor.clearValue(protocol.SpeechAttribute.LANGUAGE)
+		with self.assertRaises(KeyError):
+			self.handler._attributeValueProcessor.getValue(
+				protocol.SpeechAttribute.LANGUAGE,
+				fallBackToDefault=False,
+			)
+
+	def test_clearCache_clears_values(self):
+		self.handler._attributeValueProcessor.setValue(protocol.SpeechAttribute.LANGUAGE, "nl")
+		self.handler._attributeValueProcessor.clearCache()
+		with self.assertRaises(KeyError):
+			self.handler._attributeValueProcessor.getValue(
+				protocol.SpeechAttribute.LANGUAGE,
+				fallBackToDefault=False,
+			)
+
+	def test_clearCache_clears_pending_flag(self):
+		self.handler._attributeValueProcessor.setAttributeRequestPending(
+			protocol.SpeechAttribute.LANGUAGE,
+		)
+		self.assertTrue(
+			self.handler._attributeValueProcessor.isAttributeRequestPending(
+				protocol.SpeechAttribute.LANGUAGE,
+			),
+		)
+		self.handler._attributeValueProcessor.clearCache()
+		self.assertFalse(
+			self.handler._attributeValueProcessor.isAttributeRequestPending(
+				protocol.SpeechAttribute.LANGUAGE,
+			),
+		)
+
+
+# ---------------------------------------------------------------------------
+# 14. setAttributeRequestPending cleared by an incoming push.
+# ---------------------------------------------------------------------------
+
+
+class TestPendingCleared(unittest.TestCase):
+	def setUp(self):
+		self.handler = LanguageReceiver()
+		self.addCleanup(self.handler.terminate)
+
+	def test_pending_set_then_push_clears_it(self):
+		avp = self.handler._attributeValueProcessor
+		avp.setAttributeRequestPending(protocol.SpeechAttribute.LANGUAGE)
+		self.assertTrue(avp.isAttributeRequestPending(protocol.SpeechAttribute.LANGUAGE))
+
+		msg = buildMessage(
+			protocol.DriverType.SPEECH,
+			protocol.GenericCommand.ATTRIBUTE,
+			_attrPayload(protocol.SpeechAttribute.LANGUAGE, b"nl"),
+		)
+		self.handler._onReceive(msg)
+		self.assertFalse(avp.isAttributeRequestPending(protocol.SpeechAttribute.LANGUAGE))
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_commandDispatch.py
+++ b/tests/test_commandDispatch.py
@@ -1,0 +1,249 @@
+# RDAccess: Remote Desktop Accessibility for NVDA
+# Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
+# License: GNU General Public License version 2.0
+
+"""Unit tests for command handler registration and dispatch in RemoteProtocolHandler."""
+
+from __future__ import annotations
+
+import unittest
+
+from lib import protocol
+
+from tests._fakes import FakeHandlerBase, buildMessage
+
+# ATTRIBUTE_SEPARATOR is b"`" (0x60)
+_SEP = protocol.ATTRIBUTE_SEPARATOR
+
+
+# ---------------------------------------------------------------------------
+# Test-local subclasses
+# ---------------------------------------------------------------------------
+
+
+class _SpeakRecorder(FakeHandlerBase):
+	"""Records payloads delivered to the SPEAK command handler."""
+
+	def __init__(self):
+		super().__init__()
+		self.speak_calls: list[bytes] = []
+
+	@protocol.commandHandler(protocol.SpeechCommand.SPEAK)
+	def _command_speak(self, payload: bytes):
+		self.speak_calls.append(payload)
+
+
+class _MultiCommandRecorder(FakeHandlerBase):
+	"""Records payloads for SPEAK and CANCEL separately."""
+
+	def __init__(self):
+		super().__init__()
+		self.speak_calls: list[bytes] = []
+		self.cancel_calls: list[bytes] = []
+
+	@protocol.commandHandler(protocol.SpeechCommand.SPEAK)
+	def _command_speak(self, payload: bytes):
+		self.speak_calls.append(payload)
+
+	@protocol.commandHandler(protocol.SpeechCommand.CANCEL)
+	def _command_cancel(self, payload: bytes):
+		self.cancel_calls.append(payload)
+
+
+class _BaseWithCancel(FakeHandlerBase):
+	"""Base class that records 'base' when CANCEL is dispatched."""
+
+	def __init__(self):
+		super().__init__()
+		self.log: list[str] = []
+
+	@protocol.commandHandler(protocol.SpeechCommand.CANCEL)
+	def _command_cancel(self, _payload: bytes):
+		self.log.append("base")
+
+
+class _SubOverridesCancel(_BaseWithCancel):
+	"""Subclass that re-decorates the same method name to record 'sub'."""
+
+	@protocol.commandHandler(protocol.SpeechCommand.CANCEL)
+	def _command_cancel(self, _payload: bytes):
+		self.log.append("sub")
+
+
+class _Sub2PlainOverride(_BaseWithCancel):
+	"""Subclass that shadows _command_cancel with a plain (undecorated) method."""
+
+	def _command_cancel(self, _payload: bytes):  # plain — not a CommandHandler descriptor
+		self.log.append("plain")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCommandDispatchViaOnReceive(unittest.TestCase):
+	"""Dispatch through _onReceive (the normal in-process receive path)."""
+
+	def setUp(self):
+		self.handler = _SpeakRecorder()
+		self.addCleanup(self.handler.terminate)
+
+	def test_speak_handler_called_once_with_correct_payload(self):
+		"""_onReceive routes SPEAK to the decorated handler with the full payload."""
+		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, b"hello")
+		self.handler._onReceive(msg)
+		self.assertEqual(self.handler.speak_calls, [b"hello"])
+
+	def test_speak_handler_called_once_not_multiple_times(self):
+		"""Each message produces exactly one handler invocation."""
+		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, b"world")
+		self.handler._onReceive(msg)
+		self.assertEqual(len(self.handler.speak_calls), 1)
+
+
+class TestCommandDispatchViaStore(unittest.TestCase):
+	"""Direct dispatch through _commandHandlerStore bypasses _onReceive framing."""
+
+	def setUp(self):
+		self.handler = _SpeakRecorder()
+		self.addCleanup(self.handler.terminate)
+
+	def test_direct_store_call_invokes_handler(self):
+		"""Calling the store directly with (command, payload) invokes the registered handler."""
+		self.handler._commandHandlerStore(protocol.SpeechCommand.SPEAK, b"x")
+		self.assertEqual(self.handler.speak_calls, [b"x"])
+
+
+class TestUnknownCommandRaisesNotImplementedError(unittest.TestCase):
+	"""Dispatching an unregistered command raises NotImplementedError from the store."""
+
+	def setUp(self):
+		self.handler = _SpeakRecorder()
+		self.addCleanup(self.handler.terminate)
+
+	def test_unregistered_command_raises(self):
+		"""BEEP has no handler in _SpeakRecorder; the store must raise NotImplementedError."""
+		with self.assertRaises(NotImplementedError):
+			self.handler._commandHandlerStore(protocol.SpeechCommand.BEEP, b"")
+
+
+class TestMultipleCommandsRouteCorrectly(unittest.TestCase):
+	"""Multiple decorated handlers each receive only their own command."""
+
+	def setUp(self):
+		self.handler = _MultiCommandRecorder()
+		self.addCleanup(self.handler.terminate)
+
+	def test_speak_routes_to_speak_handler(self):
+		self.handler._commandHandlerStore(protocol.SpeechCommand.SPEAK, b"speak-payload")
+		self.assertEqual(self.handler.speak_calls, [b"speak-payload"])
+		self.assertEqual(self.handler.cancel_calls, [])
+
+	def test_cancel_routes_to_cancel_handler(self):
+		self.handler._commandHandlerStore(protocol.SpeechCommand.CANCEL, b"cancel-payload")
+		self.assertEqual(self.handler.cancel_calls, [b"cancel-payload"])
+		self.assertEqual(self.handler.speak_calls, [])
+
+	def test_both_handlers_independent(self):
+		self.handler._commandHandlerStore(protocol.SpeechCommand.SPEAK, b"s")
+		self.handler._commandHandlerStore(protocol.SpeechCommand.CANCEL, b"c")
+		self.assertEqual(self.handler.speak_calls, [b"s"])
+		self.assertEqual(self.handler.cancel_calls, [b"c"])
+
+
+class TestSubclassDecoratorOverride(unittest.TestCase):
+	"""A subclass that re-decorates the same method name wins; the base version is replaced."""
+
+	def test_sub_handler_recorded_not_base(self):
+		sub = _SubOverridesCancel()
+		self.addCleanup(sub.terminate)
+		sub._commandHandlerStore(protocol.SpeechCommand.CANCEL, b"")
+		self.assertEqual(sub.log, ["sub"])
+
+	def test_base_handler_still_records_base(self):
+		base = _BaseWithCancel()
+		self.addCleanup(base.terminate)
+		base._commandHandlerStore(protocol.SpeechCommand.CANCEL, b"")
+		self.assertEqual(base.log, ["base"])
+
+	def test_sub_does_not_record_base(self):
+		sub = _SubOverridesCancel()
+		self.addCleanup(sub.terminate)
+		sub._commandHandlerStore(protocol.SpeechCommand.CANCEL, b"")
+		self.assertNotIn("base", sub.log)
+
+
+class TestPlainOverrideUnregistersCommand(unittest.TestCase):
+	"""A plain (undecorated) override of a decorated base method shadows the registration.
+
+	This locks the current semantics: after a plain override the command has no handler.
+	"""
+
+	def test_plain_override_causes_not_implemented(self):
+		handler = _Sub2PlainOverride()
+		self.addCleanup(handler.terminate)
+		with self.assertRaises(NotImplementedError):
+			handler._commandHandlerStore(protocol.SpeechCommand.CANCEL, b"")
+
+
+class TestInstanceIsolation(unittest.TestCase):
+	"""Two instances of the same class maintain independent recording state."""
+
+	def setUp(self):
+		self.a = _SpeakRecorder()
+		self.addCleanup(self.a.terminate)
+		self.b = _SpeakRecorder()
+		self.addCleanup(self.b.terminate)
+
+	def test_dispatch_to_a_does_not_affect_b(self):
+		self.a._commandHandlerStore(protocol.SpeechCommand.SPEAK, b"for-a")
+		self.assertEqual(self.a.speak_calls, [b"for-a"])
+		self.assertEqual(self.b.speak_calls, [])
+
+	def test_dispatch_to_b_does_not_affect_a(self):
+		self.b._commandHandlerStore(protocol.SpeechCommand.SPEAK, b"for-b")
+		self.assertEqual(self.b.speak_calls, [b"for-b"])
+		self.assertEqual(self.a.speak_calls, [])
+
+
+class TestBuiltInAttributeHandler(unittest.TestCase):
+	"""GenericCommand.ATTRIBUTE is registered on every subclass.
+
+	When a peer requests NVDA_VERSION (empty rawValue), _command_attribute calls
+	_attributeSenderStore which invokes _outgoing_nvdaVersion, which writes the
+	version bytes back through FakeIo.  The stubbed versionInfo.version_detailed
+	is '2026.1.0-test'.
+	"""
+
+	def setUp(self):
+		self.handler = FakeHandlerBase()
+		self.addCleanup(self.handler.terminate)
+
+	def _make_attribute_request(self, attribute: bytes) -> bytes:
+		"""Build an ATTRIBUTE wire message that requests (empty value) the given attribute name."""
+		# payload layout: SEP + attributeName + SEP + rawValue(empty)
+		payload = _SEP + attribute + _SEP
+		return buildMessage(
+			protocol.DriverType.SPEECH,
+			protocol.GenericCommand.ATTRIBUTE,
+			payload,
+		)
+
+	def test_attribute_handler_registered(self):
+		"""ATTRIBUTE command must be dispatchable without NotImplementedError."""
+		msg = self._make_attribute_request(protocol.GenericAttribute.NVDA_VERSION)
+		# If the handler is missing this raises; we just verify it doesn't.
+		self.handler._onReceive(msg)
+
+	def test_nvda_version_request_writes_reply(self):
+		"""A NVDA_VERSION attribute request causes a write containing the version string."""
+		msg = self._make_attribute_request(protocol.GenericAttribute.NVDA_VERSION)
+		self.handler._onReceive(msg)
+		self.assertGreater(len(self.handler._dev.writes), 0, "Expected at least one write to FakeIo")
+		combined = b"".join(self.handler._dev.writes)
+		self.assertIn(b"2026.1.0-test", combined)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_framing.py
+++ b/tests/test_framing.py
@@ -1,0 +1,240 @@
+# RDAccess: Remote Desktop Accessibility for NVDA
+# Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
+# License: GNU General Public License version 2.0
+
+"""Unit tests for RemoteProtocolHandler wire-framing (_onReceive / writeMessage)."""
+
+from __future__ import annotations
+
+import contextlib
+import unittest
+
+from lib import protocol
+
+from tests._fakes import FakeHandlerBase, buildMessage
+
+# ---------------------------------------------------------------------------
+# Concrete handler used by all framing tests.
+# ---------------------------------------------------------------------------
+
+
+class SpeakCapture(FakeHandlerBase):
+	"""Records payloads delivered to the SPEAK command handler."""
+
+	def __init__(self):
+		# Initialise the capture list before super().__init__ so it is available
+		# immediately after construction (super().__init__ is safe here — __new__
+		# has already done all decorator registration).
+		self.speak_payloads: list[bytes] = []
+		super().__init__()
+
+	@protocol.commandHandler(protocol.SpeechCommand.SPEAK)
+	def _on_speak(self, payload: bytes) -> None:
+		self.speak_payloads.append(payload)
+
+
+# ---------------------------------------------------------------------------
+# 1. Complete message → handler invoked once with exact payload.
+# ---------------------------------------------------------------------------
+
+
+class TestCompleteMessage(unittest.TestCase):
+	def setUp(self):
+		self.handler = SpeakCapture()
+		self.addCleanup(self.handler.terminate)
+
+	def test_single_complete_message_dispatches_once(self):
+		payload = b"hello world"
+		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload)
+		self.handler._onReceive(msg)
+		self.assertEqual(self.handler.speak_payloads, [payload])
+
+	def test_single_complete_message_exact_payload_content(self):
+		payload = b"\x00\x01\x02\x03"
+		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload)
+		self.handler._onReceive(msg)
+		self.assertEqual(len(self.handler.speak_payloads), 1)
+		self.assertEqual(self.handler.speak_payloads[0], payload)
+
+
+# ---------------------------------------------------------------------------
+# 2. Partial delivery (split AFTER the 4-byte header).
+# ---------------------------------------------------------------------------
+
+
+class TestPartialDelivery(unittest.TestCase):
+	def setUp(self):
+		self.handler = SpeakCapture()
+		self.addCleanup(self.handler.terminate)
+
+	def test_two_way_split_after_header(self):
+		"""header + first half of payload → no dispatch; second half → dispatch once."""
+		payload = b"abcdefghij"  # 10 bytes
+		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload)
+		# Split at byte 4+5 = 9 (header is 4 bytes, split in the middle of payload)
+		split = 4 + 5
+		self.handler._onReceive(msg[:split])
+		self.assertEqual(
+			self.handler.speak_payloads,
+			[],
+			"No dispatch expected before full payload arrives",
+		)
+		self.handler._onReceive(msg[split:])
+		self.assertEqual(self.handler.speak_payloads, [payload])
+
+	def test_three_way_split(self):
+		"""Three chunks spanning the payload → exactly one dispatch with full payload."""
+		payload = b"0123456789abcdef"  # 16 bytes
+		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload)
+		# All split points are strictly after the 4-byte header.
+		split1 = 4 + 4  # header + first 4 bytes of payload
+		split2 = 4 + 10  # header + first 10 bytes of payload
+		self.handler._onReceive(msg[:split1])
+		self.assertEqual(self.handler.speak_payloads, [])
+		self.handler._onReceive(msg[split1:split2])
+		self.assertEqual(self.handler.speak_payloads, [])
+		self.handler._onReceive(msg[split2:])
+		self.assertEqual(self.handler.speak_payloads, [payload])
+
+	def test_split_one_byte_before_end(self):
+		"""All but the last payload byte in the first chunk."""
+		payload = b"xyz"
+		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload)
+		split = len(msg) - 1
+		self.handler._onReceive(msg[:split])
+		self.assertEqual(self.handler.speak_payloads, [])
+		self.handler._onReceive(msg[split:])
+		self.assertEqual(self.handler.speak_payloads, [payload])
+
+
+# ---------------------------------------------------------------------------
+# 3. Coalesced messages: two complete messages in one _onReceive call.
+# ---------------------------------------------------------------------------
+
+
+class TestCoalescedMessages(unittest.TestCase):
+	def setUp(self):
+		self.handler = SpeakCapture()
+		self.addCleanup(self.handler.terminate)
+
+	def test_two_complete_messages_both_dispatched(self):
+		payload1 = b"first"
+		payload2 = b"second"
+		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload1) + buildMessage(
+			protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload2
+		)
+		self.handler._onReceive(msg)
+		self.assertEqual(self.handler.speak_payloads, [payload1, payload2])
+
+	def test_three_complete_messages_all_dispatched_in_order(self):
+		payloads = [b"alpha", b"beta", b"gamma"]
+		msg = b"".join(
+			buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, p) for p in payloads
+		)
+		self.handler._onReceive(msg)
+		self.assertEqual(self.handler.speak_payloads, payloads)
+
+	def test_coalesced_preserves_payload_content(self):
+		payload1 = b"\xff\xfe"
+		payload2 = b"\x00"
+		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload1) + buildMessage(
+			protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload2
+		)
+		self.handler._onReceive(msg)
+		self.assertEqual(self.handler.speak_payloads[0], payload1)
+		self.assertEqual(self.handler.speak_payloads[1], payload2)
+
+
+# ---------------------------------------------------------------------------
+# 4. Coalesced partial: message1 complete + first half of message2 in one call,
+#    rest of message2 in second call.
+# ---------------------------------------------------------------------------
+
+
+class TestCoalescedPartial(unittest.TestCase):
+	def setUp(self):
+		self.handler = SpeakCapture()
+		self.addCleanup(self.handler.terminate)
+
+	def test_complete_plus_partial_then_remainder(self):
+		payload1 = b"complete"
+		payload2 = b"partial-message-payload"
+		msg1 = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload1)
+		msg2 = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload2)
+		# Split msg2 after its header, in the middle of its payload.
+		split_in_msg2 = 4 + len(payload2) // 2
+		first_chunk = msg1 + msg2[:split_in_msg2]
+		second_chunk = msg2[split_in_msg2:]
+		self.handler._onReceive(first_chunk)
+		# message1 must have been dispatched; message2 not yet.
+		self.assertEqual(self.handler.speak_payloads, [payload1])
+		self.handler._onReceive(second_chunk)
+		self.assertEqual(self.handler.speak_payloads, [payload1, payload2])
+
+	def test_two_complete_then_partial_then_rest(self):
+		"""Two complete messages, then a partial, then the rest of the partial."""
+		payloads = [b"one", b"two", b"three-is-the-long-one"]
+		msgs = [buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, p) for p in payloads]
+		# First call: msgs[0] + msgs[1] + first half of msgs[2]
+		split = 4 + len(payloads[2]) // 2
+		first_chunk = msgs[0] + msgs[1] + msgs[2][:split]
+		second_chunk = msgs[2][split:]
+		self.handler._onReceive(first_chunk)
+		self.assertEqual(self.handler.speak_payloads, [payloads[0], payloads[1]])
+		self.handler._onReceive(second_chunk)
+		self.assertEqual(self.handler.speak_payloads, payloads)
+
+
+# ---------------------------------------------------------------------------
+# 5. Wrong driverType → RuntimeError raised synchronously.
+# ---------------------------------------------------------------------------
+
+
+class TestWrongDriverType(unittest.TestCase):
+	def setUp(self):
+		self.handler = SpeakCapture()
+		self.addCleanup(self.handler.terminate)
+
+	def test_braille_drivertype_on_speech_handler_raises(self):
+		msg = buildMessage(protocol.DriverType.BRAILLE, protocol.SpeechCommand.SPEAK, b"data")
+		with self.assertRaises(RuntimeError):
+			self.handler._onReceive(msg)
+
+	def test_wrong_drivertype_no_dispatch(self):
+		"""Even though an error is raised, no SPEAK handler should have fired."""
+		msg = buildMessage(protocol.DriverType.BRAILLE, protocol.SpeechCommand.SPEAK, b"data")
+		with contextlib.suppress(RuntimeError):
+			self.handler._onReceive(msg)
+		self.assertEqual(self.handler.speak_payloads, [])
+
+
+# ---------------------------------------------------------------------------
+# 6. Empty payload message dispatches with b"".
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyPayload(unittest.TestCase):
+	def setUp(self):
+		self.handler = SpeakCapture()
+		self.addCleanup(self.handler.terminate)
+
+	def test_empty_payload_dispatches(self):
+		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, b"")
+		self.handler._onReceive(msg)
+		self.assertEqual(len(self.handler.speak_payloads), 1)
+
+	def test_empty_payload_value_is_empty_bytes(self):
+		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, b"")
+		self.handler._onReceive(msg)
+		self.assertEqual(self.handler.speak_payloads[0], b"")
+
+	def test_empty_payload_then_nonempty(self):
+		"""Empty-payload message followed by a message with payload — both dispatched."""
+		msg1 = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, b"")
+		msg2 = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, b"after")
+		self.handler._onReceive(msg1 + msg2)
+		self.assertEqual(self.handler.speak_payloads, [b"", b"after"])
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_framing.py
+++ b/tests/test_framing.py
@@ -121,7 +121,9 @@ class TestCoalescedMessages(unittest.TestCase):
 		payload1 = b"first"
 		payload2 = b"second"
 		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload1) + buildMessage(
-			protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload2
+			protocol.DriverType.SPEECH,
+			protocol.SpeechCommand.SPEAK,
+			payload2,
 		)
 		self.handler._onReceive(msg)
 		self.assertEqual(self.handler.speak_payloads, [payload1, payload2])
@@ -138,7 +140,9 @@ class TestCoalescedMessages(unittest.TestCase):
 		payload1 = b"\xff\xfe"
 		payload2 = b"\x00"
 		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload1) + buildMessage(
-			protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload2
+			protocol.DriverType.SPEECH,
+			protocol.SpeechCommand.SPEAK,
+			payload2,
 		)
 		self.handler._onReceive(msg)
 		self.assertEqual(self.handler.speak_payloads[0], payload1)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,0 +1,221 @@
+# RDAccess: Remote Desktop Accessibility for NVDA
+# Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
+# License: GNU General Public License version 2.0
+
+"""Unit tests for outgoing message construction in RemoteProtocolHandler."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+
+from lib import protocol
+
+import tests  # noqa: F401 — bootstrap sys.path + stubs
+from tests._fakes import FakeHandlerBase, buildMessage
+
+# ---------------------------------------------------------------------------
+# Helper subclasses
+# ---------------------------------------------------------------------------
+
+
+class _HandlerWithLanguageReceiver(FakeHandlerBase):
+	"""Adds a LANGUAGE attributeReceiver so attribute receipt can be tested."""
+
+	@protocol.attributeReceiver(protocol.SpeechAttribute.LANGUAGE, defaultValue="en")
+	def _incoming_language(self, payload: bytes) -> str:
+		return payload.decode()
+
+
+class _HandlerWithRecordingCommandHandler(FakeHandlerBase):
+	"""Adds a SPEAK commandHandler that records the payload it receives."""
+
+	def __init__(self):
+		super().__init__()
+		self.receivedPayloads: list[bytes] = []
+
+	@protocol.commandHandler(protocol.SpeechCommand.SPEAK)
+	def _handle_speak(self, payload: bytes):
+		self.receivedPayloads.append(payload)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestWriteMessage(unittest.TestCase):
+	"""Test 1 & 2: basic writeMessage behaviour."""
+
+	def setUp(self):
+		self.handler = FakeHandlerBase()
+		self.addCleanup(self.handler.terminate)
+
+	def test_write_message_speak_with_payload(self):
+		"""writeMessage produces the correct wire bytes for a non-empty payload."""
+		payload = b"abc"
+		self.handler.writeMessage(protocol.SpeechCommand.SPEAK, payload)
+
+		expected = b"S" + bytes([protocol.SpeechCommand.SPEAK]) + (3).to_bytes(2, sys.byteorder) + b"abc"
+		self.assertEqual(self.handler._dev.writes, [expected])
+
+	def test_write_message_matches_build_message(self):
+		"""writeMessage output is identical to buildMessage helper."""
+		payload = b"abc"
+		self.handler.writeMessage(protocol.SpeechCommand.SPEAK, payload)
+
+		expected = buildMessage(
+			protocol.DriverType.SPEECH,
+			protocol.SpeechCommand.SPEAK,
+			payload,
+		)
+		self.assertEqual(self.handler._dev.writes[0], expected)
+
+	def test_write_message_default_empty_payload(self):
+		"""writeMessage with no payload argument writes a zero-length field and no payload bytes."""
+		self.handler.writeMessage(protocol.SpeechCommand.CANCEL)
+
+		written = self.handler._dev.writes[0]
+		# Length field is bytes 2-3; must be zero
+		length_field = int.from_bytes(written[2:4], sys.byteorder)
+		self.assertEqual(length_field, 0)
+		# Total message size is exactly 4 bytes (header only)
+		self.assertEqual(len(written), 4)
+
+
+class TestLargePayloadRoundtrip(unittest.TestCase):
+	"""Test 3: large payloads encode/decode correctly through _onReceive."""
+
+	def setUp(self):
+		self.sender = FakeHandlerBase()
+		self.receiver = _HandlerWithRecordingCommandHandler()
+		self.addCleanup(self.sender.terminate)
+		self.addCleanup(self.receiver.terminate)
+
+	def test_large_payload_length_field(self):
+		"""300-byte payload encodes its length correctly in the 2-byte field."""
+		payload = bytes(range(256)) + bytes(range(44))  # 300 bytes
+		self.sender.writeMessage(protocol.SpeechCommand.SPEAK, payload)
+
+		written = self.sender._dev.writes[0]
+		length_field = int.from_bytes(written[2:4], sys.byteorder)
+		self.assertEqual(length_field, 300)
+
+	def test_large_payload_roundtrip_via_on_receive(self):
+		"""Feeding large written bytes into _onReceive dispatches the payload intact."""
+		payload = bytes(range(256)) + bytes(range(44))  # 300 bytes
+		self.sender.writeMessage(protocol.SpeechCommand.SPEAK, payload)
+
+		wire_bytes = self.sender._dev.writes[0]
+		self.receiver._onReceive(wire_bytes)
+
+		self.assertEqual(len(self.receiver.receivedPayloads), 1)
+		self.assertEqual(self.receiver.receivedPayloads[0], payload)
+
+
+class TestSetRemoteAttribute(unittest.TestCase):
+	"""Test 4: setRemoteAttribute wire format."""
+
+	def setUp(self):
+		self.handler = FakeHandlerBase()
+		self.addCleanup(self.handler.terminate)
+
+	def test_set_remote_attribute_payload_format(self):
+		"""setRemoteAttribute writes ATTRIBUTE command with `attribute`value payload."""
+		self.handler.setRemoteAttribute(b"language", b"nl")
+
+		self.assertEqual(len(self.handler._dev.writes), 1)
+		written = self.handler._dev.writes[0]
+
+		# driverType byte
+		self.assertEqual(written[0:1], b"S")
+		# command byte
+		self.assertEqual(written[1], protocol.GenericCommand.ATTRIBUTE)
+
+		# payload is everything after the 4-byte header
+		payload = written[4:]
+		expected_payload = b"`language`nl"
+		self.assertEqual(payload, expected_payload)
+
+
+class TestRequestRemoteAttribute(unittest.TestCase):
+	"""Tests 5 & 6: requestRemoteAttribute wire format and duplicate suppression."""
+
+	def setUp(self):
+		self.handler = FakeHandlerBase()
+		self.addCleanup(self.handler.terminate)
+
+	def test_request_remote_attribute_payload_format(self):
+		"""requestRemoteAttribute writes ATTRIBUTE command with trailing separator and empty value."""
+		self.handler.requestRemoteAttribute(b"language")
+
+		self.assertEqual(len(self.handler._dev.writes), 1)
+		written = self.handler._dev.writes[0]
+
+		self.assertEqual(written[0:1], b"S")
+		self.assertEqual(written[1], protocol.GenericCommand.ATTRIBUTE)
+
+		payload = written[4:]
+		# Empty value: `language` followed by separator and nothing
+		expected_payload = b"`language`"
+		self.assertEqual(payload, expected_payload)
+
+	def test_request_remote_attribute_sets_pending(self):
+		"""requestRemoteAttribute marks the attribute request as pending."""
+		self.handler.requestRemoteAttribute(b"language")
+
+		self.assertTrue(
+			self.handler._attributeValueProcessor.isAttributeRequestPending(b"language"),
+		)
+
+	def test_duplicate_request_suppressed(self):
+		"""Second requestRemoteAttribute for the same pending attribute does not write again."""
+		self.handler.requestRemoteAttribute(b"language")
+		writes_after_first = len(self.handler._dev.writes)
+
+		self.handler.requestRemoteAttribute(b"language")
+		writes_after_second = len(self.handler._dev.writes)
+
+		self.assertEqual(writes_after_first, writes_after_second)
+
+
+class TestPendingClearedOnReceipt(unittest.TestCase):
+	"""Test 7: pending flag clears and value is stored when attribute value arrives."""
+
+	def setUp(self):
+		self.handler = _HandlerWithLanguageReceiver()
+		self.addCleanup(self.handler.terminate)
+
+	def test_pending_cleared_after_value_received(self):
+		"""isAttributeRequestPending returns False after the attribute value is processed."""
+		attr = protocol.SpeechAttribute.LANGUAGE
+		self.handler.requestRemoteAttribute(attr)
+		self.assertTrue(self.handler._attributeValueProcessor.isAttributeRequestPending(attr))
+
+		self.handler._attributeValueProcessor(attr, b"nl")
+
+		self.assertFalse(self.handler._attributeValueProcessor.isAttributeRequestPending(attr))
+
+	def test_value_stored_after_receipt(self):
+		"""getValue returns the parsed value after the attribute has been pushed."""
+		attr = protocol.SpeechAttribute.LANGUAGE
+		self.handler.requestRemoteAttribute(attr)
+
+		self.handler._attributeValueProcessor(attr, b"nl")
+
+		value = self.handler._attributeValueProcessor.getValue(attr, fallBackToDefault=False)
+		self.assertEqual(value, "nl")
+
+	def test_pending_cleared_and_value_stored_without_prior_request(self):
+		"""Attribute receipt without a prior request still stores the value and leaves pending=False."""
+		attr = protocol.SpeechAttribute.LANGUAGE
+		# No requestRemoteAttribute call — just a push from the remote side
+		self.handler._attributeValueProcessor(attr, b"en-GB")
+
+		self.assertFalse(self.handler._attributeValueProcessor.isAttributeRequestPending(attr))
+		value = self.handler._attributeValueProcessor.getValue(attr, fallBackToDefault=False)
+		self.assertEqual(value, "en-GB")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -8,7 +8,9 @@ _safeWait, _pickle, _unpickle, terminate, _queueFunctionOnMainThread.
 
 from __future__ import annotations
 
+import gc
 import unittest
+import weakref
 
 import queueHandler  # noqa: E402 — must follow tests import so stubs are installed
 from baseObject import AutoPropertyObject  # noqa: E402 — same reason
@@ -132,6 +134,23 @@ class TestTerminate(unittest.TestCase):
 		handler.terminate()
 		with self.assertRaises(KeyError):
 			handler._attributeValueProcessor.getValue(b"k", fallBackToDefault=False)
+
+
+class TestGarbageCollection(unittest.TestCase):
+	"""The handler stores hold only a weak reference to their owner (see #59).
+
+	Before the #59 refactor the handler registries kept strong references to bound
+	methods (a regression from #54), creating an instance↔store cycle. This test
+	documents the restored behavior: a terminated handler is collectable.
+	"""
+
+	def test_handler_collectable_after_terminate(self):
+		handler = FakeHandlerBase()
+		handler.terminate()
+		ref = weakref.ref(handler)
+		del handler
+		gc.collect()
+		self.assertIsNone(ref(), "Handler instance should be garbage collectable after terminate()")
 
 
 class TestQueueFunctionOnMainThread(unittest.TestCase):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,184 @@
+# RDAccess: Remote Desktop Accessibility for NVDA
+# Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
+# License: GNU General Public License version 2.0
+
+"""Unit tests for utility behaviour of RemoteProtocolHandler:
+_safeWait, _pickle, _unpickle, terminate, _queueFunctionOnMainThread.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import queueHandler  # noqa: E402 — must follow tests import so stubs are installed
+from baseObject import AutoPropertyObject  # noqa: E402 — same reason
+
+from tests._fakes import FakeHandlerBase  # bootstrap runs via tests/__init__ import
+
+# ---------------------------------------------------------------------------
+# Module-level helper required by test 5 (must be picklable by reference).
+# ---------------------------------------------------------------------------
+
+
+class _PickleProbe(AutoPropertyObject):
+	"""AutoPropertyObject whose invalidateCache sets a flag for inspection."""
+
+	cachePropertiesByDefault = True
+
+	def __init__(self):
+		super().__init__()
+		self.cacheInvalidated = False
+
+	def invalidateCache(self):
+		self.cacheInvalidated = True
+		super().invalidateCache()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSafeWait(unittest.TestCase):
+	"""Tests for RemoteProtocolHandler._safeWait."""
+
+	def setUp(self):
+		self.handler = FakeHandlerBase()
+		self.addCleanup(self.handler.terminate)
+
+	def test_returns_true_immediately_when_predicate_already_true(self):
+		"""_safeWait returns True without consulting waitForRead when predicate is True on entry."""
+		result = self.handler._safeWait(lambda: True, timeout=1.0)
+		self.assertTrue(result)
+		# FakeIo.waitForReadResults is empty and returns False by default;
+		# a True result here proves waitForRead was never the deciding factor.
+
+	def test_returns_false_when_predicate_stays_false_and_read_returns_false(self):
+		"""_safeWait returns False quickly when predicate is always False and waitForRead says False."""
+		# FakeIo.waitForReadResults is empty so waitForRead always returns False immediately.
+		result = self.handler._safeWait(lambda: False, timeout=0.05)
+		self.assertFalse(result)
+
+	def test_returns_true_when_predicate_becomes_true_after_successful_read(self):
+		"""_safeWait returns True once a scripted successful read lets the predicate flip."""
+		# Script exactly one successful read result.
+		self.handler._dev.waitForReadResults = [True]
+
+		calls = []
+
+		def _predicate() -> bool:
+			calls.append(len(calls))
+			# False on first call, True on second (after the scripted read).
+			return len(calls) >= 2
+
+		result = self.handler._safeWait(_predicate, timeout=1.0)
+		self.assertTrue(result)
+		self.assertGreaterEqual(len(calls), 2)
+
+
+class TestPickleUnpickle(unittest.TestCase):
+	"""Tests for RemoteProtocolHandler._pickle and _unpickle."""
+
+	def setUp(self):
+		self.handler = FakeHandlerBase()
+		self.addCleanup(self.handler.terminate)
+
+	def test_roundtrip_plain_structure(self):
+		"""_unpickle(_pickle(obj)) reproduces the original plain structure."""
+		original = {"key": b"bytes_value", "name": "hello", "count": 42}
+		raw = self.handler._pickle(original)
+		restored = self.handler._unpickle(raw)
+		self.assertEqual(restored, original)
+
+	def test_unpickle_calls_invalidate_cache_on_auto_property_object(self):
+		"""_unpickle calls invalidateCache on AutoPropertyObject results."""
+		probe = _PickleProbe()
+		raw = self.handler._pickle(probe)
+		result = self.handler._unpickle(raw)
+		self.assertIsInstance(result, _PickleProbe)
+		self.assertTrue(result.cacheInvalidated)
+
+	def test_unpickle_does_not_call_invalidate_cache_on_plain_objects(self):
+		"""_unpickle does not call invalidateCache on non-AutoPropertyObject results."""
+		# dict has no invalidateCache; if _unpickle tried to call it this would raise.
+		data = {"x": 1}
+		raw = self.handler._pickle(data)
+		result = self.handler._unpickle(raw)
+		self.assertEqual(result, data)
+
+
+class TestTerminate(unittest.TestCase):
+	"""Tests for RemoteProtocolHandler.terminate."""
+
+	def test_terminate_closes_device(self):
+		"""After terminate(), the underlying IO device is closed."""
+		handler = FakeHandlerBase()
+		# Seed the cache directly to avoid needing a registered attribute receiver.
+		handler._attributeValueProcessor._values[b"k"] = 1
+		handler.terminate()
+		self.assertTrue(handler._dev.closed)
+
+	def test_terminate_shuts_down_executor(self):
+		"""After terminate(), the background executor is shut down."""
+		handler = FakeHandlerBase()
+		handler.terminate()
+		self.assertTrue(handler._bgExecutor.isShutdown)
+
+	def test_terminate_clears_attribute_cache(self):
+		"""After terminate(), previously stored attribute values are gone from the cache."""
+		handler = FakeHandlerBase()
+		# Seed the cache directly to avoid needing a registered attribute receiver.
+		handler._attributeValueProcessor._values[b"k"] = 1
+		handler.terminate()
+		with self.assertRaises(KeyError):
+			handler._attributeValueProcessor.getValue(b"k", fallBackToDefault=False)
+
+
+class TestQueueFunctionOnMainThread(unittest.TestCase):
+	"""Tests for RemoteProtocolHandler._queueFunctionOnMainThread."""
+
+	def setUp(self):
+		self.handler = FakeHandlerBase()
+		self.addCleanup(self.handler.terminate)
+
+	def test_function_not_called_before_pump(self):
+		"""The queued function must not execute before pumpAll() is called."""
+		calls: list[tuple] = []
+
+		def _record(*args, **kwargs):
+			calls.append((args, kwargs))
+
+		self.handler._queueFunctionOnMainThread(_record, 1, k=2)
+		self.assertEqual(calls, [], "Function must not run synchronously; call pumpAll first")
+
+	def test_function_called_once_with_correct_args_after_pump(self):
+		"""After pumpAll() the function runs exactly once with the forwarded arguments."""
+		calls: list[tuple] = []
+
+		def _record(*args, **kwargs):
+			calls.append((args, kwargs))
+
+		self.handler._queueFunctionOnMainThread(_record, 1, k=2)
+		queueHandler.pumpAll()
+
+		self.assertEqual(len(calls), 1)
+		args, kwargs = calls[0]
+		self.assertEqual(args, (1,))
+		self.assertEqual(kwargs, {"k": 2})
+
+	def test_exception_in_queued_function_does_not_propagate(self):
+		"""pumpAll() must not raise even if the queued function itself raises."""
+
+		def _boom():
+			raise RuntimeError("intentional error")
+
+		self.handler._queueFunctionOnMainThread(_boom)
+		# Must not raise.
+		try:
+			queueHandler.pumpAll()
+		except Exception as exc:  # noqa: BLE001
+			self.fail(f"pumpAll() raised unexpectedly: {exc}")
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
Closes #59.

## Summary
- Handler stores no longer subclass `extensionPoints.HandlerRegistrar` holding `MethodType`-bound methods. `RemoteProtocolHandler.__new__` now registers the class-level handler descriptors themselves, and each store holds a **weak** reference to its owning handler, passed explicitly on dispatch. `HandlerDecoratorBase.__get__` and the dead `unregister`/`_rebuildIndex`/`partial`+`cast` paths are removed.
- All nine `# ty: ignore[...]` suppressions in `addon/lib/protocol/__init__.py` are gone; `uv run ty check` stays at 0 diagnostics. Bound-form type aliases were replaced with honest unbound `Callable` forms.
- The weak owner reference also fixes a regression from #54: the O(1) index dicts kept strong refs to bound methods, creating an instance↔store cycle. A terminated handler is now garbage collectable (asserted by a dedicated test).
- New unit test suite (`tests/`, stdlib unittest, 90 tests) written **first against the old code** to lock dispatch behavior, green before and after the refactor. NVDA leaf modules are stubbed in `sys.modules`; the real `baseObject`/`extensionPoints` come from the sibling `..\nvda\source` checkout (which CI already clones). Tests run as a prek hook and a CI step.

## Test Plan
- [x] `uv run python -m unittest discover -s tests -t .` — 90/90 green
- [x] `uv run prek run --all-files` — all hooks pass (ruff, ty, unittest)
- [x] `uv run scons` — builds `rdAccess-1.7.1.nvda-addon`
- [ ] Manual smoke test against a real RDP/Citrix session (unit tests cover protocol logic, not pipe/NVDA integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)