### PR TITLE
Protocol v2: JSON Lines wire protocol replacing pickle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,11 +55,11 @@ Dual-stack: two wire formats coexist on each pipe, negotiated automatically per 
 
 **Negotiation**: both sides push a `protocolVersion` attribute at connect (client on pipe connect, server after XON). Receive side sniffs the first byte per message (`{` = JSON line, driverType byte = legacy frame; `_onReceive`). Send side stays legacy until the peer is known to be ≥ v2 (explicit version, or any received JSON line), then flips (`_sendJson`) and emits a one-shot `protocol_version` message with a `channel` field validated against the pipe's channel. Old peers never answer the version push, so `defaultValue=1` keeps everything legacy. Legacy removal is planned for a later release.
 
-`RemoteProtocolHandler` (in `protocol/__init__.py`) is the abstract base, used by both driver classes (server side) and handler classes (client side). All dispatch funnels through `_handleMessage(messageType, kwargs)`; sends go through `sendMessage(messageType, **payload)`. Three decorator-driven registries are populated at `__new__` time by introspecting the class:
+`RemoteProtocolHandler` (in `protocol/__init__.py`) is the abstract base, used by both driver classes (server side) and handler classes (client side). All dispatch funnels through `_handleMessage(messageType, kwargs)` → `_commandHandlerStore`; the built-in message types (`attribute_request`/`attribute_value`/`protocol_version`/`ping`) are ordinary `@commandHandler` methods on the base, so subclasses can override any message type through the same registry. Sends go through `sendMessage(messageType, **payload)`. Three decorator-driven registries are populated at `__new__` time by introspecting the class:
 
 * `@commandHandler(RdMessageType.X)` → `CommandHandlerStore` — dispatch incoming messages; handlers receive decoded kwargs.
 * `@attributeSender(attr)` → `AttributeSenderStore` — return the Python value when peer requests `attr`.
-* `@attributeReceiver(attr, defaultValue=…)` → `AttributeValueProcessor` — accept the decoded value when peer pushes `attr`; `.defaultValueGetter` and `.updateCallback` are settable via the returned descriptor.
+* `@attributeReceiver(attr, defaultValue=…)` → `AttributeValueProcessor` — accept the decoded value when peer pushes `attr`; `.defaultValueGetter` and `.updateCallback` are settable via the returned descriptor. When the decoded value needs no transformation, assign a bare `AttributeReceiver(attr, defaultValue=…)` as a class attribute instead of decorating an identity method.
 
 Attributes are `str`; wildcards are allowed (`*` matched via `fnmatch`) — `_incoming_setting` is the catch-all for `setting_*` attributes used to forward driver settings (voice, pitch, dot-firmness, etc.) bidirectionally.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,21 +47,21 @@ Client-side detection of new pipes uses `directoryChanges.DirectoryWatcher` (Rea
 
 ### Protocol (`addon/lib/protocol/`)
 
-Wire format on each pipe:
+Dual-stack: two wire formats coexist on each pipe, negotiated automatically per connection.
 
-```
-[driverType:1][command:1][payloadLen:2 LE][payload...]
-```
+**Protocol v2 (JSON Lines)** — modeled on NVDA core's `_remoteClient` protocol: one UTF-8 JSON object per `\n`-terminated line with a mandatory `"type"` field. Message types are `RdMessageType(StrEnum)` in `messages.py`; names/values mirror `RemoteMessageType` where semantics match (`speak`, `cancel`, `pause_speech`, `tone`, `wave`, `index`, `display`, `braille_input`, `protocol_version`, `ping`), plus RDAccess-specific `attribute_request`/`attribute_value`. `serializer.py` (`RdJSONSerializer`) encodes speech sequences byte-for-byte identically to `_remoteClient.serializer` (`[ClassName, __dict__]` pairs); RDAccess-specific values (DriverSetting family, VoiceInfo, GlobalGestureMap via `export()`/`update()`, `supportedCommands` class-name lists) extend the same convention with explicit per-attribute decode allowlists. Conformance tests (`tests/test_serializerConformance.py`) load `..\nvda\source\_remoteClient\{serializer,protocol}.py` by file path and fail when NVDA core drifts.
 
-`driverType` ∈ `{S, B}` (`DriverType.SPEECH/BRAILLE`). `command` is one of `GenericCommand.ATTRIBUTE` (`@`), `SpeechCommand.*`, or `BrailleCommand.*`. The `ATTRIBUTE` command carries `` `attributeName`value `` — empty value means "send me yours" (request), non-empty means "here is mine" (push).
+**Protocol v1 (legacy, binary + pickle)** — `[driverType:1][command:1][payloadLen:2 LE][payload...]`; `driverType` ∈ `{S, B}`. All v1 byte formats live in `legacy.py`, which translates frames to/from the same value-based messages (`encode/decodeCommandPayload`, `encode/decodeAttributeValue`); pickled payloads pass through `_restrictedUnpickling.RestrictedUnpickler` only.
 
-`RemoteProtocolHandler` (in `protocol/__init__.py`) is the abstract base, used by both driver classes (server side) and handler classes (client side). It uses three decorator-driven registries populated at `__new__` time by introspecting the class:
+**Negotiation**: both sides push a `protocolVersion` attribute at connect (client on pipe connect, server after XON). Receive side sniffs the first byte per message (`{` = JSON line, driverType byte = legacy frame; `_onReceive`). Send side stays legacy until the peer is known to be ≥ v2 (explicit version, or any received JSON line), then flips (`_sendJson`) and emits a one-shot `protocol_version` message with a `channel` field validated against the pipe's channel. Old peers never answer the version push, so `defaultValue=1` keeps everything legacy. Legacy removal is planned for a later release.
 
-* `@commandHandler(cmd)` → `CommandHandlerStore` — dispatch incoming commands.
-* `@attributeSender(attr)` → `AttributeSenderStore` — produce bytes when peer requests `attr`.
-* `@attributeReceiver(attr, defaultValue=…)` → `AttributeValueProcessor` — parse bytes when peer pushes `attr`; `.defaultValueGetter` and `.updateCallback` are settable via the returned descriptor.
+`RemoteProtocolHandler` (in `protocol/__init__.py`) is the abstract base, used by both driver classes (server side) and handler classes (client side). All dispatch funnels through `_handleMessage(messageType, kwargs)`; sends go through `sendMessage(messageType, **payload)`. Three decorator-driven registries are populated at `__new__` time by introspecting the class:
 
-Wildcards are allowed (`*` matched via `fnmatch`) — `_incoming_setting` is the catch-all for `setting_*` attributes used to forward driver settings (voice, pitch, dot-firmness, etc.) bidirectionally. Payloads for non-trivial values are pickled with `protocol=4` (`_pickle`/`_unpickle`).
+* `@commandHandler(RdMessageType.X)` → `CommandHandlerStore` — dispatch incoming messages; handlers receive decoded kwargs.
+* `@attributeSender(attr)` → `AttributeSenderStore` — return the Python value when peer requests `attr`.
+* `@attributeReceiver(attr, defaultValue=…)` → `AttributeValueProcessor` — accept the decoded value when peer pushes `attr`; `.defaultValueGetter` and `.updateCallback` are settable via the returned descriptor.
+
+Attributes are `str`; wildcards are allowed (`*` matched via `fnmatch`) — `_incoming_setting` is the catch-all for `setting_*` attributes used to forward driver settings (voice, pitch, dot-firmness, etc.) bidirectionally.
 
 `AttributeReceiver` callbacks run on a per-handler `ThreadPoolExecutor(4)`. Anything touching NVDA core state must hop back via `_queueFunctionOnMainThread` (queues onto `queueHandler.eventQueue`).
 

--- a/addon/brailleDisplayDrivers/remote.py
+++ b/addon/brailleDisplayDrivers/remote.py
@@ -51,32 +51,24 @@ class RemoteBrailleDisplayDriver(driver.RemoteDriver, braille.BrailleDisplayDriv
 			assert braille.handler is not None
 			braille.handler.handleDisplayUnavailable()
 
-	@protocol.attributeReceiver(protocol.BrailleAttribute.NUM_CELLS, defaultValue=0)
-	def _incoming_numCells(self, value: int) -> int:
-		return value
+	_incoming_numCells = protocol.AttributeReceiver(protocol.BrailleAttribute.NUM_CELLS, defaultValue=0)
 
 	def _get_numCells(self) -> int:
 		if (value := self.numRows * self.numCols) == 0:
 			value = self._getRemoteAttributeValueWithFallback(protocol.BrailleAttribute.NUM_CELLS)
 		return value
 
-	@protocol.attributeReceiver(protocol.BrailleAttribute.NUM_ROWS, defaultValue=1)
-	def _incoming_numRows(self, value: int) -> int:
-		return value
+	_incoming_numRows = protocol.AttributeReceiver(protocol.BrailleAttribute.NUM_ROWS, defaultValue=1)
 
 	def _get_numRows(self) -> int:
 		return self._getRemoteAttributeValueWithFallback(protocol.BrailleAttribute.NUM_ROWS)
 
-	@protocol.attributeReceiver(protocol.BrailleAttribute.NUM_COLS, defaultValue=0)
-	def _incoming_numCols(self, value: int) -> int:
-		return value
+	_incoming_numCols = protocol.AttributeReceiver(protocol.BrailleAttribute.NUM_COLS, defaultValue=0)
 
 	def _get_numCols(self) -> int:
 		return self._getRemoteAttributeValueWithFallback(protocol.BrailleAttribute.NUM_COLS)
 
-	@protocol.attributeReceiver(protocol.BrailleAttribute.GESTURE_MAP)
-	def _incoming_gestureMapUpdate(self, value: inputCore.GlobalGestureMap) -> inputCore.GlobalGestureMap:
-		return value
+	_incoming_gestureMapUpdate = protocol.AttributeReceiver(protocol.BrailleAttribute.GESTURE_MAP)
 
 	@_incoming_gestureMapUpdate.defaultValueGetter
 	def _default_gestureMap(self, _attribute: protocol.AttributeT):

--- a/addon/brailleDisplayDrivers/remote.py
+++ b/addon/brailleDisplayDrivers/remote.py
@@ -52,9 +52,8 @@ class RemoteBrailleDisplayDriver(driver.RemoteDriver, braille.BrailleDisplayDriv
 			braille.handler.handleDisplayUnavailable()
 
 	@protocol.attributeReceiver(protocol.BrailleAttribute.NUM_CELLS, defaultValue=0)
-	def _incoming_numCells(self, payload: bytes) -> int:
-		assert len(payload) == 1
-		return ord(payload)
+	def _incoming_numCells(self, value: int) -> int:
+		return value
 
 	def _get_numCells(self) -> int:
 		if (value := self.numRows * self.numCols) == 0:
@@ -62,25 +61,22 @@ class RemoteBrailleDisplayDriver(driver.RemoteDriver, braille.BrailleDisplayDriv
 		return value
 
 	@protocol.attributeReceiver(protocol.BrailleAttribute.NUM_ROWS, defaultValue=1)
-	def _incoming_numRows(self, payload: bytes) -> int:
-		assert len(payload) == 1
-		return ord(payload)
+	def _incoming_numRows(self, value: int) -> int:
+		return value
 
 	def _get_numRows(self) -> int:
 		return self._getRemoteAttributeValueWithFallback(protocol.BrailleAttribute.NUM_ROWS)
 
 	@protocol.attributeReceiver(protocol.BrailleAttribute.NUM_COLS, defaultValue=0)
-	def _incoming_numCols(self, payload: bytes) -> int:
-		assert len(payload) == 1
-		return ord(payload)
+	def _incoming_numCols(self, value: int) -> int:
+		return value
 
 	def _get_numCols(self) -> int:
 		return self._getRemoteAttributeValueWithFallback(protocol.BrailleAttribute.NUM_COLS)
 
 	@protocol.attributeReceiver(protocol.BrailleAttribute.GESTURE_MAP)
-	def _incoming_gestureMapUpdate(self, payload: bytes) -> inputCore.GlobalGestureMap:
-		assert len(payload) > 0
-		return self._unpickle(payload)
+	def _incoming_gestureMapUpdate(self, value: inputCore.GlobalGestureMap) -> inputCore.GlobalGestureMap:
+		return value
 
 	@_incoming_gestureMapUpdate.defaultValueGetter
 	def _default_gestureMap(self, _attribute: protocol.AttributeT):

--- a/addon/brailleDisplayDrivers/remote.py
+++ b/addon/brailleDisplayDrivers/remote.py
@@ -85,10 +85,9 @@ class RemoteBrailleDisplayDriver(driver.RemoteDriver, braille.BrailleDisplayDriv
 	def _get_gestureMap(self) -> inputCore.GlobalGestureMap:
 		return self._getRemoteAttributeValueWithFallback(protocol.BrailleAttribute.GESTURE_MAP)
 
-	@protocol.commandHandler(protocol.BrailleCommand.EXECUTE_GESTURE)
-	def _command_executeGesture(self, payload: bytes):
-		assert len(payload) > 0
-		gesture = self._unpickle(payload)
+	@protocol.commandHandler(protocol.RdMessageType.BRAILLE_INPUT)
+	def _command_brailleInput(self, **kwargs):
+		gesture = protocol.braille.BrailleInputGesture(**kwargs)
 		assert inputCore.manager is not None
 		try:
 			inputCore.manager.executeGesture(gesture)
@@ -100,8 +99,7 @@ class RemoteBrailleDisplayDriver(driver.RemoteDriver, braille.BrailleDisplayDriv
 		assert len(cells) == self.numCells
 		if len(cells) == 0:
 			return
-		arg = bytes(cells)
-		self.writeMessage(protocol.BrailleCommand.DISPLAY, arg)
+		self.sendMessage(protocol.RdMessageType.DISPLAY, cells=cells)
 
 
 BrailleDisplayDriver = RemoteBrailleDisplayDriver

--- a/addon/globalPlugins/rdAccess/handlers/_remoteHandler.py
+++ b/addon/globalPlugins/rdAccess/handlers/_remoteHandler.py
@@ -3,7 +3,6 @@
 # License: GNU General Public License version 2.0
 
 import os.path
-import sys
 import typing
 from abc import abstractmethod
 
@@ -114,38 +113,36 @@ class RemoteHandler[DriverT: Driver](protocol.RemoteProtocolHandler[namedPipe.Na
 		self._remoteSessionhasFocus = None
 
 	@protocol.attributeSender(protocol.GenericAttribute.SUPPORTED_SETTINGS)
-	def _outgoing_supportedSettings(self, settings=None) -> bytes:
+	def _outgoing_supportedSettings(self, settings=None):
 		if not configuration.getDriverSettingsManagement():
-			return self._pickle([])
+			return []
 		if settings is None:
 			settings = self._driver.supportedSettings
-		return self._pickle(settings)
+		return settings
 
-	@protocol.attributeSender(b"available*s")
-	def _outgoing_availableSettingValues(self, attribute: protocol.AttributeT) -> bytes:
+	@protocol.attributeSender("available*s")
+	def _outgoing_availableSettingValues(self, attribute: protocol.AttributeT):
 		if not configuration.getDriverSettingsManagement():
-			return self._pickle({})
-		name = attribute.decode("ASCII")
-		return self._pickle(getattr(self._driver, name))
+			return {}
+		return getattr(self._driver, attribute)
 
-	@protocol.attributeReceiver(protocol.SETTING_ATTRIBUTE_PREFIX + b"*")
-	def _incoming_setting(self, _attribute: protocol.AttributeT, payLoad: bytes):
-		assert len(payLoad) > 0
-		return self._unpickle(payLoad)
+	@protocol.attributeReceiver(protocol.SETTING_ATTRIBUTE_PREFIX + "*")
+	def _incoming_setting(self, _attribute: protocol.AttributeT, value: typing.Any):
+		return value
 
 	@_incoming_setting.updateCallback
 	def _setIncomingSettingOnDriver(self, attribute: protocol.AttributeT, value: typing.Any):
 		if not configuration.getDriverSettingsManagement():
 			return
-		name = attribute[len(protocol.SETTING_ATTRIBUTE_PREFIX) :].decode("ASCII")
+		name = attribute[len(protocol.SETTING_ATTRIBUTE_PREFIX) :]
 		setattr(self._driver, name, value)
 
-	@protocol.attributeSender(protocol.SETTING_ATTRIBUTE_PREFIX + b"*")
+	@protocol.attributeSender(protocol.SETTING_ATTRIBUTE_PREFIX + "*")
 	def _outgoing_setting(self, attribute: protocol.AttributeT):
 		if not configuration.getDriverSettingsManagement():
-			return self._pickle(None)
-		name = attribute[len(protocol.SETTING_ATTRIBUTE_PREFIX) :].decode("ASCII")
-		return self._pickle(getattr(self._driver, name))
+			return None
+		name = attribute[len(protocol.SETTING_ATTRIBUTE_PREFIX) :]
+		return getattr(self._driver, name)
 
 	_remoteProcessHasFocus: bool
 
@@ -173,9 +170,8 @@ class RemoteHandler[DriverT: Driver](protocol.RemoteProtocolHandler[namedPipe.Na
 		return False
 
 	@protocol.attributeReceiver(protocol.GenericAttribute.TIME_SINCE_INPUT, defaultValue=False)
-	def _incoming_timeSinceInput(self, payload: bytes) -> int:
-		assert len(payload) == 4
-		return int.from_bytes(payload, byteorder=sys.byteorder, signed=False)
+	def _incoming_timeSinceInput(self, value: int) -> int:
+		return value
 
 	@_incoming_timeSinceInput.updateCallback
 	def _post_timeSinceInput(self, attribute: protocol.AttributeT, value: int):

--- a/addon/globalPlugins/rdAccess/handlers/_remoteHandler.py
+++ b/addon/globalPlugins/rdAccess/handlers/_remoteHandler.py
@@ -127,9 +127,7 @@ class RemoteHandler[DriverT: Driver](protocol.RemoteProtocolHandler[namedPipe.Na
 			return {}
 		return getattr(self._driver, attribute)
 
-	@protocol.attributeReceiver(protocol.SETTING_ATTRIBUTE_PREFIX + "*")
-	def _incoming_setting(self, _attribute: protocol.AttributeT, value: typing.Any):
-		return value
+	_incoming_setting = protocol.AttributeReceiver(protocol.SETTING_ATTRIBUTE_PREFIX + "*")
 
 	@_incoming_setting.updateCallback
 	def _setIncomingSettingOnDriver(self, attribute: protocol.AttributeT, value: typing.Any):
@@ -170,9 +168,10 @@ class RemoteHandler[DriverT: Driver](protocol.RemoteProtocolHandler[namedPipe.Na
 		self.requestRemoteAttribute(attribute)
 		return False
 
-	@protocol.attributeReceiver(protocol.GenericAttribute.TIME_SINCE_INPUT, defaultValue=False)
-	def _incoming_timeSinceInput(self, value: int) -> int:
-		return value
+	_incoming_timeSinceInput = protocol.AttributeReceiver(
+		protocol.GenericAttribute.TIME_SINCE_INPUT,
+		defaultValue=False,
+	)
 
 	@_incoming_timeSinceInput.updateCallback
 	def _post_timeSinceInput(self, attribute: protocol.AttributeT, value: int):

--- a/addon/globalPlugins/rdAccess/handlers/_remoteHandler.py
+++ b/addon/globalPlugins/rdAccess/handlers/_remoteHandler.py
@@ -70,6 +70,7 @@ class RemoteHandler[DriverT: Driver](protocol.RemoteProtocolHandler[namedPipe.Na
 
 	def _onConnected(self, connected: bool = True):
 		if connected:
+			self.pushProtocolVersion()
 			self._handleDriverChanged(self._driver)
 		wx.CallAfter(self._handleNotifications, connected)
 

--- a/addon/globalPlugins/rdAccess/handlers/remoteBrailleHandler.py
+++ b/addon/globalPlugins/rdAccess/handlers/remoteBrailleHandler.py
@@ -9,7 +9,7 @@ import braille
 import brailleInput
 import inputCore
 from brailleViewer import postBrailleViewerToolToggledAction
-from hwIo import IoThread, intToByte
+from hwIo import IoThread
 from logHandler import log
 
 from ._remoteHandler import RemoteHandler
@@ -48,31 +48,34 @@ class RemoteBrailleHandler(RemoteHandler[braille.BrailleDisplayDriver]):
 		return braille.handler.display
 
 	@protocol.attributeSender(protocol.BrailleAttribute.NUM_CELLS)
-	def _outgoing_numCells(self, numCells=None) -> bytes:
+	def _outgoing_numCells(self, numCells=None) -> int:
 		if numCells is None:
 			# Use the display size of the local braille handler
 			assert braille.handler is not None
 			numCells = braille.handler.displaySize
-		return intToByte(numCells)
+		return numCells
 
 	@protocol.attributeSender(protocol.BrailleAttribute.NUM_COLS)
-	def _outgoing_numCols(self, numCols=None) -> bytes:
+	def _outgoing_numCols(self, numCols=None) -> int:
 		if numCols is None:
 			# Use the display dimensions of the local braille handler
 			assert braille.handler is not None
 			numCols = braille.handler.displayDimensions.numCols
-		return intToByte(numCols)
+		return numCols
 
 	@protocol.attributeSender(protocol.BrailleAttribute.NUM_ROWS)
-	def _outgoing_numRows(self, numRows=None) -> bytes:
+	def _outgoing_numRows(self, numRows=None) -> int:
 		if numRows is None:
 			# Use the display dimensions of the local braille handler
 			assert braille.handler is not None
 			numRows = braille.handler.displayDimensions.numRows
-		return intToByte(numRows)
+		return numRows
 
 	@protocol.attributeSender(protocol.BrailleAttribute.GESTURE_MAP)
-	def _outgoing_gestureMap(self, gestureMap: inputCore.GlobalGestureMap | None = None) -> bytes:
+	def _outgoing_gestureMap(
+		self,
+		gestureMap: inputCore.GlobalGestureMap | None = None,
+	) -> inputCore.GlobalGestureMap | None:
 		if gestureMap is None:
 			gestureMap = self._driver.gestureMap
 		if gestureMap:
@@ -80,7 +83,7 @@ class RemoteBrailleHandler(RemoteHandler[braille.BrailleDisplayDriver]):
 			gestureMap = inputCore.GlobalGestureMap(export)
 			assert inputCore.manager is not None
 			gestureMap.update(inputCore.manager.userGestureMap.export())
-		return self._pickle(gestureMap)
+		return gestureMap
 
 	@protocol.commandHandler(protocol.BrailleCommand.DISPLAY)
 	def _command_display(self, payload: bytes):

--- a/addon/globalPlugins/rdAccess/handlers/remoteBrailleHandler.py
+++ b/addon/globalPlugins/rdAccess/handlers/remoteBrailleHandler.py
@@ -85,9 +85,8 @@ class RemoteBrailleHandler(RemoteHandler[braille.BrailleDisplayDriver]):
 			gestureMap.update(inputCore.manager.userGestureMap.export())
 		return gestureMap
 
-	@protocol.commandHandler(protocol.BrailleCommand.DISPLAY)
-	def _command_display(self, payload: bytes):
-		cells = list(payload)
+	@protocol.commandHandler(protocol.RdMessageType.DISPLAY)
+	def _command_display(self, cells: list[int]):
 		assert braille.handler is not None
 		if braille.handler.displaySize > 0:
 			with self._queuedWriteLock:
@@ -125,9 +124,8 @@ class RemoteBrailleHandler(RemoteHandler[braille.BrailleDisplayDriver]):
 			if isinstance(gesture, brailleInput.BrailleInputGesture):
 				kwargs["dots"] = gesture.dots
 				kwargs["space"] = gesture.space
-			newGesture = protocol.braille.BrailleInputGesture(**kwargs)
 			try:
-				self.writeMessage(protocol.BrailleCommand.EXECUTE_GESTURE, self._pickle(newGesture))
+				self.sendMessage(protocol.RdMessageType.BRAILLE_INPUT, **kwargs)
 				return False
 			except OSError:
 				log.warning("Error calling _handleExecuteGesture", exc_info=True)

--- a/addon/globalPlugins/rdAccess/handlers/remoteSpeechHandler.py
+++ b/addon/globalPlugins/rdAccess/handlers/remoteSpeechHandler.py
@@ -48,16 +48,16 @@ class RemoteSpeechHandler(RemoteHandler[synthDriverHandler.SynthDriver]):
 		return synth
 
 	@protocol.attributeSender(protocol.SpeechAttribute.SUPPORTED_COMMANDS)
-	def _outgoing_supportedCommands(self, commands=None) -> bytes:
+	def _outgoing_supportedCommands(self, commands=None):
 		if commands is None:
 			commands = self._driver.supportedCommands
-		return self._pickle(commands)
+		return commands
 
 	@protocol.attributeSender(protocol.SpeechAttribute.LANGUAGE)
-	def _outgoing_language(self, language: str | None = None) -> bytes:
+	def _outgoing_language(self, language: str | None = None) -> str | None:
 		if language is None:
 			language = self._driver.language
-		return self._pickle(language)
+		return language
 
 	@protocol.commandHandler(protocol.SpeechCommand.SPEAK)
 	def _command_speak(self, payload: bytes):

--- a/addon/globalPlugins/rdAccess/handlers/remoteSpeechHandler.py
+++ b/addon/globalPlugins/rdAccess/handlers/remoteSpeechHandler.py
@@ -2,7 +2,6 @@
 # Copyright 2023 Leonard de Ruijter <alderuijter@gmail.com>
 # License: GNU General Public License version 2.0
 
-import sys
 import typing
 
 import nvwave
@@ -59,9 +58,8 @@ class RemoteSpeechHandler(RemoteHandler[synthDriverHandler.SynthDriver]):
 			language = self._driver.language
 		return language
 
-	@protocol.commandHandler(protocol.SpeechCommand.SPEAK)
-	def _command_speak(self, payload: bytes):
-		sequence = self._unpickle(payload)
+	@protocol.commandHandler(protocol.RdMessageType.SPEAK)
+	def _command_speak(self, sequence: SpeechSequence):
 		self._queueFunctionOnMainThread(self._speak, sequence)
 
 	def _speak(self, sequence: SpeechSequence):
@@ -79,8 +77,8 @@ class RemoteSpeechHandler(RemoteHandler[synthDriverHandler.SynthDriver]):
 		speech.speech._speechState.beenCanceled = False
 		self._driver.speak(sequence)
 
-	@protocol.commandHandler(protocol.SpeechCommand.CANCEL)
-	def _command_cancel(self, _payload: bytes = b""):
+	@protocol.commandHandler(protocol.RdMessageType.CANCEL)
+	def _command_cancel(self):
 		self._indexesSpeaking.clear()
 		self._queueFunctionOnMainThread(self._cancel)
 
@@ -90,26 +88,22 @@ class RemoteSpeechHandler(RemoteHandler[synthDriverHandler.SynthDriver]):
 		speech.speech._speechState.beenCanceled = True
 		speech.speech._speechState.isPaused = False
 
-	@protocol.commandHandler(protocol.SpeechCommand.PAUSE)
-	def _command_pause(self, payload: bytes):
-		assert len(payload) == 1
-		switch = bool.from_bytes(payload, sys.byteorder)
+	@protocol.commandHandler(protocol.RdMessageType.PAUSE_SPEECH)
+	def _command_pause(self, switch: bool):
 		self._queueFunctionOnMainThread(self._pause, switch)
 
 	def _pause(self, switch: bool):
 		speech.pauseSpeech(switch)
 
-	@protocol.commandHandler(protocol.SpeechCommand.BEEP)
-	def _command_beep(self, payload: bytes):
-		kwargs = self._unpickle(payload)
-		log.debug(f"Received BEEP command: {kwargs}")
+	@protocol.commandHandler(protocol.RdMessageType.TONE)
+	def _command_beep(self, **kwargs):
+		log.debug(f"Received TONE command: {kwargs}")
 		# Tones are always asynchronous
 		tones.beep(**kwargs)
 
-	@protocol.commandHandler(protocol.SpeechCommand.PLAY_WAVE_FILE)
-	def _command_playWaveFile(self, payload: bytes):
-		kwargs = self._unpickle(payload)
-		log.debug(f"Received PLAY_WAVE_FILE command: {kwargs}")
+	@protocol.commandHandler(protocol.RdMessageType.WAVE)
+	def _command_playWaveFile(self, **kwargs):
+		log.debug(f"Received WAVE command: {kwargs}")
 		# Ensure the wave plays asynchronous.
 		kwargs["asynchronous"] = True
 		nvwave.playWaveFile(**kwargs)
@@ -122,13 +116,8 @@ class RemoteSpeechHandler(RemoteHandler[synthDriverHandler.SynthDriver]):
 		assert synth == self._driver
 		if index in self._indexesSpeaking:
 			subtractedIndex = index - protocol.speech.SPEECH_INDEX_OFFSET
-			indexBytes = subtractedIndex.to_bytes(
-				length=2,  # Bytes needed to encode speech._manager.MAX_INDEX
-				byteorder=sys.byteorder,  # for a single byte big/little endian does not matter.
-				signed=False,
-			)
 			try:
-				self.writeMessage(protocol.SpeechCommand.INDEX_REACHED, indexBytes)
+				self.sendMessage(protocol.RdMessageType.INDEX, index=subtractedIndex)
 			except OSError:
 				log.warning("Error calling _onSynthIndexReached", exc_info=True)
 			self._indexesSpeaking.remove(index)
@@ -138,7 +127,7 @@ class RemoteSpeechHandler(RemoteHandler[synthDriverHandler.SynthDriver]):
 		if len(self._indexesSpeaking) > 0:
 			self._indexesSpeaking.clear()
 			try:
-				self.writeMessage(protocol.SpeechCommand.INDEX_REACHED, b"\x00\x00")
+				self.sendMessage(protocol.RdMessageType.INDEX, index=0)
 			except OSError:
 				log.warning("Error calling _onSynthDoneSpeaking", exc_info=True)
 

--- a/addon/lib/driver/__init__.py
+++ b/addon/lib/driver/__init__.py
@@ -26,8 +26,6 @@ _AUTO_PROPERTY_OBJECT_NAMES: frozenset[str] = frozenset(
 
 ERROR_INVALID_HANDLE = 0x6
 ERROR_PIPE_NOT_CONNECTED = 0xE9
-MSG_XON = protocol.MSG_XON
-MSG_XOFF = protocol.MSG_XOFF
 
 
 class RemoteDriver(protocol.RemoteProtocolHandler, driverHandler.Driver):
@@ -139,11 +137,11 @@ class RemoteDriver(protocol.RemoteProtocolHandler, driverHandler.Driver):
 	def _onReceive(self, message: bytes):
 		if len(message) == 1:
 			command = message[0]
-			if command == MSG_XON:
+			if command == protocol.MSG_XON:
 				self._connected = True
 				self.pushProtocolVersion()
 				return
-			elif command == MSG_XOFF:
+			elif command == protocol.MSG_XOFF:
 				log.debugWarning("MSG_XOFF message received, connection closed")
 				self._handleRemoteDisconnect()
 				return
@@ -179,13 +177,8 @@ class RemoteDriver(protocol.RemoteProtocolHandler, driverHandler.Driver):
 			settings.extend(self.getRemoteAttribute(attribute))
 		return settings
 
-	@protocol.attributeReceiver(protocol.SETTING_ATTRIBUTE_PREFIX + "*")
-	def _incoming_setting(self, _attribute: protocol.AttributeT, value: Any):
-		return value
-
-	@protocol.attributeReceiver("available*s")
-	def _incoming_availableSettingValues(self, _attribute: protocol.AttributeT, value: Any):
-		return value
+	_incoming_setting = protocol.AttributeReceiver(protocol.SETTING_ATTRIBUTE_PREFIX + "*")
+	_incoming_availableSettingValues = protocol.AttributeReceiver("available*s")
 
 	@protocol.attributeSender(protocol.GenericAttribute.TIME_SINCE_INPUT)
 	def _outgoing_timeSinceInput(self) -> int:

--- a/addon/lib/driver/__init__.py
+++ b/addon/lib/driver/__init__.py
@@ -3,7 +3,6 @@
 # License: GNU General Public License version 2.0
 from __future__ import annotations
 
-import sys
 import time
 from abc import abstractmethod
 from collections.abc import Iterable, Iterator, Sequence
@@ -150,9 +149,7 @@ class RemoteDriver(protocol.RemoteProtocolHandler, driverHandler.Driver):
 		super()._onReceive(message)
 
 	@protocol.attributeReceiver(protocol.GenericAttribute.SUPPORTED_SETTINGS, defaultValue=[])
-	def _incomingSupportedSettings(self, payLoad: bytes):
-		assert len(payLoad) > 0
-		settings = self._unpickle(payLoad)
+	def _incomingSupportedSettings(self, settings: Sequence[DriverSetting]):
 		for s in settings:
 			s.useConfig = False
 		return settings
@@ -181,18 +178,17 @@ class RemoteDriver(protocol.RemoteProtocolHandler, driverHandler.Driver):
 			settings.extend(self.getRemoteAttribute(attribute))
 		return settings
 
-	@protocol.attributeReceiver(protocol.SETTING_ATTRIBUTE_PREFIX + b"*")
-	def _incoming_setting(self, _attribute: protocol.AttributeT, payLoad: bytes):
-		assert len(payLoad) > 0
-		return self._unpickle(payLoad)
+	@protocol.attributeReceiver(protocol.SETTING_ATTRIBUTE_PREFIX + "*")
+	def _incoming_setting(self, _attribute: protocol.AttributeT, value: Any):
+		return value
 
-	@protocol.attributeReceiver(b"available*s")
-	def _incoming_availableSettingValues(self, _attribute: protocol.AttributeT, payLoad: bytes):
-		return self._unpickle(payLoad)
+	@protocol.attributeReceiver("available*s")
+	def _incoming_availableSettingValues(self, _attribute: protocol.AttributeT, value: Any):
+		return value
 
 	@protocol.attributeSender(protocol.GenericAttribute.TIME_SINCE_INPUT)
-	def _outgoing_timeSinceInput(self) -> bytes:
-		return inputTime.getTimeSinceInput().to_bytes(4, sys.byteorder, signed=False)
+	def _outgoing_timeSinceInput(self) -> int:
+		return inputTime.getTimeSinceInput()
 
 	def _handlePossibleSessionDisconnect(self):
 		if not self.check():

--- a/addon/lib/driver/__init__.py
+++ b/addon/lib/driver/__init__.py
@@ -141,6 +141,7 @@ class RemoteDriver(protocol.RemoteProtocolHandler, driverHandler.Driver):
 			command = message[0]
 			if command == MSG_XON:
 				self._connected = True
+				self.pushProtocolVersion()
 				return
 			elif command == MSG_XOFF:
 				log.debugWarning("MSG_XOFF message received, connection closed")

--- a/addon/lib/driver/__init__.py
+++ b/addon/lib/driver/__init__.py
@@ -27,8 +27,8 @@ _AUTO_PROPERTY_OBJECT_NAMES: frozenset[str] = frozenset(
 
 ERROR_INVALID_HANDLE = 0x6
 ERROR_PIPE_NOT_CONNECTED = 0xE9
-MSG_XON = 0x11
-MSG_XOFF = 0x13
+MSG_XON = protocol.MSG_XON
+MSG_XOFF = protocol.MSG_XOFF
 
 
 class RemoteDriver(protocol.RemoteProtocolHandler, driverHandler.Driver):

--- a/addon/lib/driver/settingsAccessor.py
+++ b/addon/lib/driver/settingsAccessor.py
@@ -57,7 +57,7 @@ class SettingsAccessorBase(AutoPropertyObject):
 
 	@classmethod
 	def _getSettingAttributeName(cls, setting: str) -> protocol.AttributeT:
-		return protocol.SETTING_ATTRIBUTE_PREFIX + setting.encode("ASCII")
+		return protocol.SETTING_ATTRIBUTE_PREFIX + setting
 
 	@classmethod
 	def _getAvailableSettingsPropertyName(cls, setting: str) -> str:
@@ -65,7 +65,7 @@ class SettingsAccessorBase(AutoPropertyObject):
 
 	@classmethod
 	def _getAvailableSettingsAttributeName(cls, setting: str) -> protocol.AttributeT:
-		return cls._getAvailableSettingsPropertyName(setting).encode("ASCII")
+		return cls._getAvailableSettingsPropertyName(setting)
 
 	@classmethod
 	def _makeGetSetting(cls, setting: str):
@@ -83,7 +83,7 @@ class SettingsAccessorBase(AutoPropertyObject):
 		def _setSetting(self: SettingsAccessorBase, value: Any):
 			log.debug(f"Setting value for setting {setting} to {value}")
 			attribute = self._getSettingAttributeName(setting)
-			self.driver.setRemoteAttribute(attribute, self.driver._pickle(value))
+			self.driver.setRemoteAttribute(attribute, value)
 			if self.driver._attributeValueProcessor.isAttributeSupported(attribute):
 				self.driver._attributeValueProcessor.setValue(attribute, value)
 

--- a/addon/lib/protocol/__init__.py
+++ b/addon/lib/protocol/__init__.py
@@ -364,6 +364,8 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 	_bgExecutor: ThreadPoolExecutor
 	# Stateless, so shared by all handlers.
 	_serializer: RdJSONSerializer = RdJSONSerializer()
+	_sendJson: bool = False
+	_jsonHandshakeSent: bool = False
 
 	def __new__(cls, *args, **kwargs):
 		self = super().__new__(cls, *args, **kwargs)
@@ -512,6 +514,27 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 	def _incoming_protocolVersion(self, value: int) -> int:
 		return value
 
+	@_incoming_protocolVersion.updateCallback
+	def _post_protocolVersion(self, _attribute: AttributeT, value: int):
+		self._handlePeerProtocolVersionChange(value)
+
+	def _handlePeerProtocolVersionChange(self, version: int):
+		if version < PROTOCOL_VERSION or self._sendJson:
+			return
+		log.debug(f"Peer speaks protocol version {version}, switching to JSON Lines on {self!r}")
+		self._sendJson = True
+		if not self._jsonHandshakeSent:
+			self._jsonHandshakeSent = True
+			self.sendMessage(
+				RdMessageType.PROTOCOL_VERSION,
+				version=PROTOCOL_VERSION,
+				channel=CHANNEL_NAMES[self.driverType],
+			)
+
+	def pushProtocolVersion(self):
+		"""Push our protocol version to the peer; call once when a connection is established."""
+		self._attributeSenderStore(GenericAttribute.PROTOCOL_VERSION)
+
 	@abstractmethod
 	def _incoming_setting(self, attribute: AttributeT, value: Any):
 		raise NotImplementedError
@@ -520,8 +543,11 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 		self._dev.write(legacy.packFrame(self.driverType, command, payload))
 
 	def sendMessage(self, messageType: RdMessageType, **payload: Any):
-		command, data = legacy.encodeCommandPayload(self.driverType, messageType, payload)
-		self.writeMessage(command, data)
+		if self._sendJson:
+			self._dev.write(self._serializer.serialize(type=messageType, **payload))
+		else:
+			command, data = legacy.encodeCommandPayload(self.driverType, messageType, payload)
+			self.writeMessage(command, data)
 
 	def setRemoteAttribute(self, attribute: AttributeT, value: Any):
 		log.debug(f"Setting remote attribute {attribute!r} to value {value!r}")

--- a/addon/lib/protocol/__init__.py
+++ b/addon/lib/protocol/__init__.py
@@ -28,7 +28,8 @@ from . import legacy
 from ._restrictedUnpickling import restrictedLoads
 from .braille import BrailleAttribute, BrailleCommand
 from .legacy import ATTRIBUTE_SEPARATOR, MSG_XOFF, MSG_XON, GenericCommand
-from .messages import PROTOCOL_VERSION, DriverType, RdMessageType
+from .messages import CHANNEL_NAMES, PROTOCOL_VERSION, DriverType, RdMessageType
+from .serializer import RdJSONSerializer
 from .speech import SpeechAttribute, SpeechCommand
 
 __all__ = [
@@ -361,6 +362,8 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 	timeout: float = 1.0
 	cachePropertiesByDefault = True
 	_bgExecutor: ThreadPoolExecutor
+	# Stateless, so shared by all handlers.
+	_serializer: RdJSONSerializer = RdJSONSerializer()
 
 	def __new__(cls, *args, **kwargs):
 		self = super().__new__(cls, *args, **kwargs)
@@ -403,34 +406,68 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 		if self._receiveBuffer:
 			message = self._receiveBuffer + message
 			self._receiveBuffer = b""
-		if not message[0] == self.driverType:
-			raise RuntimeError(f"Unexpected payload: {message}")
+		while message:
+			firstByte = message[0]
+			if firstByte == RdJSONSerializer.SEP[0]:
+				# Tolerate stray separators between JSON lines.
+				message = message[1:]
+			elif firstByte == ord("{"):
+				line, sep, message = message.partition(RdJSONSerializer.SEP)
+				if not sep:
+					self._receiveBuffer = line
+					return
+				self._bgExecutor.submit(self._handleJsonLine, line)
+			elif firstByte == self.driverType:
+				message = self._parseLegacyFrame(message)
+			else:
+				raise RuntimeError(f"Unexpected payload: {message}")
+
+	def _parseLegacyFrame(self, message: bytes) -> bytes:
+		"""Parse one legacy frame from ``message``, buffering partial frames.
+
+		Returns the remaining bytes after the frame, or ``b""`` when the frame is
+		incomplete and has been stashed in the receive buffer.
+		"""
+		if len(message) < 4:
+			self._receiveBuffer = message
+			return b""
 		command = message[1]
 		expectedLength = int.from_bytes(message[2:4], sys.byteorder)
-		payload = message[4:]
-		actualLength = len(payload)
-		remainder: bytes | None = None
-		if expectedLength != actualLength:
+		endOfPayload = 4 + expectedLength
+		if len(message) < endOfPayload:
 			log.debug(
 				f"Expected payload of length {expectedLength}, "
-				f"actual length of payload {payload!r} is {actualLength}",
+				f"received {len(message) - 4} payload bytes so far",
 			)
-			if expectedLength > actualLength:
-				self._receiveBuffer = message
-				return
-			else:
-				remainder = payload[expectedLength:]
-				payload = payload[:expectedLength]
-
-		try:
-			self._bgExecutor.submit(self._handleLegacyFrame, command, payload)
-		finally:
-			if remainder:
-				self._onReceive(remainder)
+			self._receiveBuffer = message
+			return b""
+		payload = message[4:endOfPayload]
+		self._bgExecutor.submit(self._handleLegacyFrame, command, payload)
+		return message[endOfPayload:]
 
 	def _handleLegacyFrame(self, command: int, payload: bytes):
 		messageType, kwargs = legacy.decodeCommandPayload(self.driverType, command, payload)
 		self._handleMessage(messageType, kwargs)
+
+	def _handleJsonLine(self, line: bytes):
+		try:
+			obj = self._serializer.deserialize(line)
+		except ValueError:
+			log.error(f"Error parsing incoming JSON line: {line!r}", exc_info=True)
+			return
+		if not isinstance(obj, dict):
+			log.error(f"Incoming JSON line is not an object: {line!r}")
+			return
+		# A peer that speaks JSON is at least version 2, whether or not its
+		# protocol_version message has arrived yet.
+		self._notePeerProtocolVersion(PROTOCOL_VERSION)
+		typeValue = obj.pop("type", None)
+		try:
+			messageType = RdMessageType(typeValue)
+		except ValueError:
+			log.warning(f"Unknown message type received: {typeValue!r}")
+			return
+		self._handleMessage(messageType, obj)
 
 	def _handleMessage(self, messageType: RdMessageType, kwargs: dict[str, Any]):
 		log.debug(f"Handling message of type {messageType!r} on {self!r}")
@@ -439,10 +476,41 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 				self._attributeSenderStore(kwargs["attribute"])
 			case RdMessageType.ATTRIBUTE_VALUE:
 				self._attributeValueProcessor(kwargs["attribute"], kwargs["value"])
+			case RdMessageType.PROTOCOL_VERSION:
+				self._handleProtocolVersionMessage(**kwargs)
 			case RdMessageType.PING:
 				pass
 			case _:
 				self._commandHandlerStore(messageType, **kwargs)
+
+	def _handleProtocolVersionMessage(self, version: int, channel: str | None = None):
+		if channel is not None and channel != CHANNEL_NAMES[self.driverType]:
+			log.error(f"Protocol version message for unexpected channel {channel!r} on {self!r}")
+			return
+		self._notePeerProtocolVersion(version)
+
+	def _notePeerProtocolVersion(self, version: int):
+		current = self._attributeValueProcessor.getValue(
+			GenericAttribute.PROTOCOL_VERSION,
+			fallBackToDefault=True,
+		)
+		if version > current:
+			self._attributeValueProcessor.setValue(GenericAttribute.PROTOCOL_VERSION, version)
+
+	@property
+	def _peerProtocolVersion(self) -> int:
+		return self._attributeValueProcessor.getValue(
+			GenericAttribute.PROTOCOL_VERSION,
+			fallBackToDefault=True,
+		)
+
+	@attributeSender(GenericAttribute.PROTOCOL_VERSION)
+	def _outgoing_protocolVersion(self) -> int:
+		return PROTOCOL_VERSION
+
+	@attributeReceiver(GenericAttribute.PROTOCOL_VERSION, defaultValue=1)
+	def _incoming_protocolVersion(self, value: int) -> int:
+		return value
 
 	@abstractmethod
 	def _incoming_setting(self, attribute: AttributeT, value: Any):

--- a/addon/lib/protocol/__init__.py
+++ b/addon/lib/protocol/__init__.py
@@ -15,10 +15,7 @@ from concurrent.futures import ThreadPoolExecutor
 from enum import StrEnum
 from fnmatch import fnmatch
 from functools import partial, update_wrapper, wraps
-from typing import (
-	Any,
-	cast,
-)
+from typing import Any
 
 import addonHandler
 import queueHandler
@@ -75,7 +72,7 @@ AttributeT = str
 # Handler functions are stored unbound; the first parameter is the RemoteProtocolHandler instance.
 # It is typed as Any because typing it precisely would make subclass methods (whose self is the
 # subclass) unassignable due to parameter contravariance.
-CommandHandlerFuncT = Callable[[Any, bytes], None]
+CommandHandlerFuncT = Callable[..., None]
 # Attribute handler functions vary in arity: catch-all handlers receive the concrete attribute as an
 # extra argument and senders may take additional (keyword) arguments.
 AttributeFetcherT = Callable[..., Any]
@@ -108,19 +105,19 @@ class HandlerDecoratorBase[HandlerFuncT: Callable]:
 
 
 class CommandHandler(HandlerDecoratorBase[CommandHandlerFuncT]):
-	_command: CommandT
+	_messageType: RdMessageType
 
-	def __init__(self, command: CommandT, func: CommandHandlerFuncT):
+	def __init__(self, messageType: RdMessageType, func: CommandHandlerFuncT):
 		super().__init__(func)
-		self._command = command
+		self._messageType = messageType
 
-	def __call__(self, protocolHandler: RemoteProtocolHandler, payload: bytes):
-		log.debug(f"Calling {self!r} for command {self._command!r}")
-		return self._func(protocolHandler, payload)
+	def __call__(self, protocolHandler: RemoteProtocolHandler, **kwargs):
+		log.debug(f"Calling {self!r} for message type {self._messageType!r}")
+		return self._func(protocolHandler, **kwargs)
 
 
-def commandHandler(command: CommandT):
-	return partial(CommandHandler, command)
+def commandHandler(messageType: RdMessageType):
+	return partial(CommandHandler, messageType)
 
 
 class AttributeHandler[AttributeHandlerFuncT: Callable](HandlerDecoratorBase[AttributeHandlerFuncT]):
@@ -233,21 +230,21 @@ class HandlerStoreBase:
 
 
 class CommandHandlerStore(HandlerStoreBase):
-	_commandIndex: dict[CommandT, CommandHandler]
+	_commandIndex: dict[RdMessageType, CommandHandler]
 
 	def __init__(self, owner: RemoteProtocolHandler):
 		super().__init__(owner)
 		self._commandIndex = {}
 
 	def register(self, handler: CommandHandler):
-		self._commandIndex[handler._command] = handler
+		self._commandIndex[handler._messageType] = handler
 
-	def __call__(self, command: CommandT, payload: bytes):
-		log.debug(f"Getting handler on {self!r} to process command {command!r}")
-		handler = self._commandIndex.get(command)
+	def __call__(self, messageType: RdMessageType, **kwargs):
+		log.debug(f"Getting handler on {self!r} to process message type {messageType!r}")
+		handler = self._commandIndex.get(messageType)
 		if handler is None:
-			raise NotImplementedError(f"No command handler for command {command!r}")
-		handler(self._getOwner(), payload)
+			raise NotImplementedError(f"No command handler for message type {messageType!r}")
+		handler(self._getOwner(), **kwargs)
 
 
 class AttributeHandlerStore[AttributeHandlerT: AttributeHandler](HandlerStoreBase):
@@ -408,7 +405,7 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 			self._receiveBuffer = b""
 		if not message[0] == self.driverType:
 			raise RuntimeError(f"Unexpected payload: {message}")
-		command = cast(CommandT, message[1])
+		command = message[1]
 		expectedLength = int.from_bytes(message[2:4], sys.byteorder)
 		payload = message[4:]
 		actualLength = len(payload)
@@ -426,25 +423,26 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 				payload = payload[:expectedLength]
 
 		try:
-			self._bgExecutor.submit(self._commandHandlerStore, command, payload)
+			self._bgExecutor.submit(self._handleLegacyFrame, command, payload)
 		finally:
 			if remainder:
 				self._onReceive(remainder)
 
-	@commandHandler(GenericCommand.ATTRIBUTE)
-	def _command_attribute(self, payload: bytes):
-		messageType, kwargs = legacy.decodeCommandPayload(
-			self.driverType,
-			GenericCommand.ATTRIBUTE,
-			payload,
-		)
-		attribute = kwargs["attribute"]
-		if messageType is RdMessageType.ATTRIBUTE_REQUEST:
-			log.debug(f"No value sent for attribute {attribute!r} on {self!r}, expecting a reply")
-			self._attributeSenderStore(attribute)
-		else:
-			log.debug(f"Value sent for attribute {attribute!r} on {self!r}, direction incoming")
-			self._attributeValueProcessor(attribute, kwargs["value"])
+	def _handleLegacyFrame(self, command: int, payload: bytes):
+		messageType, kwargs = legacy.decodeCommandPayload(self.driverType, command, payload)
+		self._handleMessage(messageType, kwargs)
+
+	def _handleMessage(self, messageType: RdMessageType, kwargs: dict[str, Any]):
+		log.debug(f"Handling message of type {messageType!r} on {self!r}")
+		match messageType:
+			case RdMessageType.ATTRIBUTE_REQUEST:
+				self._attributeSenderStore(kwargs["attribute"])
+			case RdMessageType.ATTRIBUTE_VALUE:
+				self._attributeValueProcessor(kwargs["attribute"], kwargs["value"])
+			case RdMessageType.PING:
+				pass
+			case _:
+				self._commandHandlerStore(messageType, **kwargs)
 
 	@abstractmethod
 	def _incoming_setting(self, attribute: AttributeT, value: Any):
@@ -453,14 +451,13 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 	def writeMessage(self, command: CommandT | int, payload: bytes = b""):
 		self._dev.write(legacy.packFrame(self.driverType, command, payload))
 
+	def sendMessage(self, messageType: RdMessageType, **payload: Any):
+		command, data = legacy.encodeCommandPayload(self.driverType, messageType, payload)
+		self.writeMessage(command, data)
+
 	def setRemoteAttribute(self, attribute: AttributeT, value: Any):
 		log.debug(f"Setting remote attribute {attribute!r} to value {value!r}")
-		command, payload = legacy.encodeCommandPayload(
-			self.driverType,
-			RdMessageType.ATTRIBUTE_VALUE,
-			{"attribute": attribute, "value": value},
-		)
-		return self.writeMessage(command, payload)
+		self.sendMessage(RdMessageType.ATTRIBUTE_VALUE, attribute=attribute, value=value)
 
 	def requestRemoteAttribute(self, attribute: AttributeT):
 		if self._attributeValueProcessor.isAttributeRequestPending(attribute):
@@ -468,12 +465,7 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 			return
 		log.debug(f"Requesting remote attribute {attribute!r}")
 		self._attributeValueProcessor.setAttributeRequestPending(attribute)
-		command, payload = legacy.encodeCommandPayload(
-			self.driverType,
-			RdMessageType.ATTRIBUTE_REQUEST,
-			{"attribute": attribute},
-		)
-		self.writeMessage(command, payload)
+		self.sendMessage(RdMessageType.ATTRIBUTE_REQUEST, attribute=attribute)
 
 	def _safeWait(self, predicate: Callable[[], bool], timeout: float | None = None):
 		if timeout is None:

--- a/addon/lib/protocol/__init__.py
+++ b/addon/lib/protocol/__init__.py
@@ -4,15 +4,12 @@
 from __future__ import annotations
 
 import inspect
-import pickle
-import sys
 import time
 import weakref
 from abc import abstractmethod
 from collections import defaultdict
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
-from enum import StrEnum
 from fnmatch import fnmatch
 from functools import partial, update_wrapper, wraps
 from typing import Any
@@ -25,10 +22,17 @@ from hwIo.base import IoBase
 from logHandler import log
 
 from . import legacy
-from ._restrictedUnpickling import restrictedLoads
 from .braille import BrailleAttribute, BrailleCommand
-from .legacy import ATTRIBUTE_SEPARATOR, MSG_XOFF, MSG_XON, GenericCommand
-from .messages import CHANNEL_NAMES, PROTOCOL_VERSION, DriverType, RdMessageType
+from .legacy import ATTRIBUTE_SEPARATOR, GenericCommand
+from .messages import (
+	CHANNEL_NAMES,
+	MSG_XOFF,
+	MSG_XON,
+	PROTOCOL_VERSION,
+	DriverType,
+	GenericAttribute,
+	RdMessageType,
+)
 from .serializer import RdJSONSerializer
 from .speech import SpeechAttribute, SpeechCommand
 
@@ -38,10 +42,10 @@ __all__ = [
 	"MSG_XON",
 	"PROTOCOL_VERSION",
 	"SETTING_ATTRIBUTE_PREFIX",
+	"AttributeReceiver",
 	"AttributeT",
 	"BrailleAttribute",
 	"BrailleCommand",
-	"CommandT",
 	"DriverType",
 	"GenericAttribute",
 	"GenericCommand",
@@ -53,22 +57,11 @@ __all__ = [
 	"attributeSender",
 	"commandHandler",
 	"legacy",
-	"restrictedLoads",
 ]
 
 addon: addonHandler.Addon = addonHandler.getCodeAddon()
 SETTING_ATTRIBUTE_PREFIX = "setting_"
 
-
-class GenericAttribute(StrEnum):
-	TIME_SINCE_INPUT = "timeSinceInput"
-	SUPPORTED_SETTINGS = "supportedSettings"
-	NVDA_VERSION = "nvdaVersion"
-	RD_ACCESS_VERSION = "rdAccessVersion"
-	PROTOCOL_VERSION = "protocolVersion"
-
-
-CommandT = GenericCommand | SpeechCommand | BrailleCommand
 AttributeT = str
 # Handler functions are stored unbound; the first parameter is the RemoteProtocolHandler instance.
 # It is typed as Any because typing it precisely would make subclass methods (whose self is the
@@ -161,19 +154,40 @@ def attributeSender(attribute: AttributeT):
 	return partial(AttributeSender, attribute)
 
 
+def _identityReceiver(_protocolHandler: Any, *args: Any) -> Any:
+	return args[-1]
+
+
+def _constantDefaultValueGetter(defaultValue: Any) -> DefaultValueGetterT:
+	def _defaultValueGetter(_self: RemoteProtocolHandler, _attribute: AttributeT):
+		return defaultValue
+
+	return _defaultValueGetter
+
+
 class AttributeReceiver(AttributeHandler[AttributeReceiverFuncT]):
+	"""Receiver for a remote attribute value.
+
+	Usable as a bare class attribute when the decoded value needs no transformation,
+	or applied to a method (via the :func:`attributeReceiver` decorator) that
+	normalizes the value before it is stored.
+	"""
+
 	_defaultValueGetter: DefaultValueGetterT
 	_updateCallback: AttributeValueUpdateCallbackT | None
 
 	def __init__(
 		self,
 		attribute: AttributeT,
-		func: AttributeReceiverFuncT,
-		defaultValueGetter: DefaultValueGetterT,
-		updateCallback: AttributeValueUpdateCallbackT | None,
+		func: AttributeReceiverFuncT | None = None,
+		defaultValue: Any = None,
+		defaultValueGetter: DefaultValueGetterT | None = None,
+		updateCallback: AttributeValueUpdateCallbackT | None = None,
 	):
-		super().__init__(attribute, func)
-		self._defaultValueGetter = defaultValueGetter
+		if defaultValue is not None and defaultValueGetter is not None:
+			raise ValueError("Either defaultValue or defaultValueGetter is required, but not both")
+		super().__init__(attribute, func if func is not None else _identityReceiver)
+		self._defaultValueGetter = defaultValueGetter or _constantDefaultValueGetter(defaultValue)
 		self._updateCallback = updateCallback
 
 	def defaultValueGetter(self, func: DefaultValueGetterT):
@@ -185,13 +199,6 @@ class AttributeReceiver(AttributeHandler[AttributeReceiverFuncT]):
 		return func
 
 
-def _constantDefaultValueGetter(defaultValue: Any) -> DefaultValueGetterT:
-	def _defaultValueGetter(_self: RemoteProtocolHandler, _attribute: AttributeT):
-		return defaultValue
-
-	return _defaultValueGetter
-
-
 def attributeReceiver(
 	attribute: AttributeT,
 	defaultValue: Any = None,
@@ -200,11 +207,10 @@ def attributeReceiver(
 ):
 	if defaultValue is not None and defaultValueGetter is not None:
 		raise ValueError("Either defaultValue or defaultValueGetter is required, but not both")
-	if defaultValueGetter is None:
-		defaultValueGetter = _constantDefaultValueGetter(defaultValue)
 	return partial(
 		AttributeReceiver,
 		attribute,
+		defaultValue=defaultValue,
 		defaultValueGetter=defaultValueGetter,
 		updateCallback=updateCallback,
 	)
@@ -365,7 +371,6 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 	# Stateless, so shared by all handlers.
 	_serializer: RdJSONSerializer = RdJSONSerializer()
 	_sendJson: bool = False
-	_jsonHandshakeSent: bool = False
 
 	def __new__(cls, *args, **kwargs):
 		self = super().__new__(cls, *args, **kwargs)
@@ -425,27 +430,19 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 				raise RuntimeError(f"Unexpected payload: {message}")
 
 	def _parseLegacyFrame(self, message: bytes) -> bytes:
-		"""Parse one legacy frame from ``message``, buffering partial frames.
+		"""Dispatch one legacy frame from ``message``, buffering partial frames.
 
 		Returns the remaining bytes after the frame, or ``b""`` when the frame is
 		incomplete and has been stashed in the receive buffer.
 		"""
-		if len(message) < 4:
+		parsed = legacy.parseFrame(message)
+		if parsed is None:
+			log.debug(f"Incomplete legacy frame, buffering {len(message)} bytes")
 			self._receiveBuffer = message
 			return b""
-		command = message[1]
-		expectedLength = int.from_bytes(message[2:4], sys.byteorder)
-		endOfPayload = 4 + expectedLength
-		if len(message) < endOfPayload:
-			log.debug(
-				f"Expected payload of length {expectedLength}, "
-				f"received {len(message) - 4} payload bytes so far",
-			)
-			self._receiveBuffer = message
-			return b""
-		payload = message[4:endOfPayload]
+		command, payload, rest = parsed
 		self._bgExecutor.submit(self._handleLegacyFrame, command, payload)
-		return message[endOfPayload:]
+		return rest
 
 	def _handleLegacyFrame(self, command: int, payload: bytes):
 		messageType, kwargs = legacy.decodeCommandPayload(self.driverType, command, payload)
@@ -473,30 +470,29 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 
 	def _handleMessage(self, messageType: RdMessageType, kwargs: dict[str, Any]):
 		log.debug(f"Handling message of type {messageType!r} on {self!r}")
-		match messageType:
-			case RdMessageType.ATTRIBUTE_REQUEST:
-				self._attributeSenderStore(kwargs["attribute"])
-			case RdMessageType.ATTRIBUTE_VALUE:
-				self._attributeValueProcessor(kwargs["attribute"], kwargs["value"])
-			case RdMessageType.PROTOCOL_VERSION:
-				self._handleProtocolVersionMessage(**kwargs)
-			case RdMessageType.PING:
-				pass
-			case _:
-				self._commandHandlerStore(messageType, **kwargs)
+		self._commandHandlerStore(messageType, **kwargs)
 
-	def _handleProtocolVersionMessage(self, version: int, channel: str | None = None):
+	@commandHandler(RdMessageType.ATTRIBUTE_REQUEST)
+	def _command_attributeRequest(self, attribute: AttributeT):
+		self._attributeSenderStore(attribute)
+
+	@commandHandler(RdMessageType.ATTRIBUTE_VALUE)
+	def _command_attributeValue(self, attribute: AttributeT, value: Any):
+		self._attributeValueProcessor(attribute, value)
+
+	@commandHandler(RdMessageType.PING)
+	def _command_ping(self):
+		pass
+
+	@commandHandler(RdMessageType.PROTOCOL_VERSION)
+	def _command_protocolVersion(self, version: int, channel: str | None = None):
 		if channel is not None and channel != CHANNEL_NAMES[self.driverType]:
 			log.error(f"Protocol version message for unexpected channel {channel!r} on {self!r}")
 			return
 		self._notePeerProtocolVersion(version)
 
 	def _notePeerProtocolVersion(self, version: int):
-		current = self._attributeValueProcessor.getValue(
-			GenericAttribute.PROTOCOL_VERSION,
-			fallBackToDefault=True,
-		)
-		if version > current:
+		if version > self._peerProtocolVersion:
 			self._attributeValueProcessor.setValue(GenericAttribute.PROTOCOL_VERSION, version)
 
 	@property
@@ -512,7 +508,7 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 
 	@attributeReceiver(GenericAttribute.PROTOCOL_VERSION, defaultValue=1)
 	def _incoming_protocolVersion(self, value: int) -> int:
-		return value
+		return max(value, self._peerProtocolVersion)
 
 	@_incoming_protocolVersion.updateCallback
 	def _post_protocolVersion(self, _attribute: AttributeT, value: int):
@@ -523,13 +519,11 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 			return
 		log.debug(f"Peer speaks protocol version {version}, switching to JSON Lines on {self!r}")
 		self._sendJson = True
-		if not self._jsonHandshakeSent:
-			self._jsonHandshakeSent = True
-			self.sendMessage(
-				RdMessageType.PROTOCOL_VERSION,
-				version=PROTOCOL_VERSION,
-				channel=CHANNEL_NAMES[self.driverType],
-			)
+		self.sendMessage(
+			RdMessageType.PROTOCOL_VERSION,
+			version=PROTOCOL_VERSION,
+			channel=CHANNEL_NAMES[self.driverType],
+		)
 
 	def pushProtocolVersion(self):
 		"""Push our protocol version to the peer; call once when a connection is established."""
@@ -539,15 +533,12 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 	def _incoming_setting(self, attribute: AttributeT, value: Any):
 		raise NotImplementedError
 
-	def writeMessage(self, command: CommandT | int, payload: bytes = b""):
-		self._dev.write(legacy.packFrame(self.driverType, command, payload))
-
 	def sendMessage(self, messageType: RdMessageType, **payload: Any):
 		if self._sendJson:
 			self._dev.write(self._serializer.serialize(type=messageType, **payload))
 		else:
 			command, data = legacy.encodeCommandPayload(self.driverType, messageType, payload)
-			self.writeMessage(command, data)
+			self._dev.write(legacy.packFrame(self.driverType, command, data))
 
 	def setRemoteAttribute(self, attribute: AttributeT, value: Any):
 		log.debug(f"Setting remote attribute {attribute!r} to value {value!r}")
@@ -617,15 +608,6 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 			log.debug(f"Waiting for attribute {attribute} failed")
 		return result
 
-	def _pickle(self, obj: Any):
-		return pickle.dumps(obj, protocol=4)
-
-	def _unpickle(self, payload: bytes) -> Any:
-		res = restrictedLoads(payload)
-		if isinstance(res, AutoPropertyObject):
-			res.invalidateCache()
-		return res
-
 	def _queueFunctionOnMainThread(self, func, *args, **kwargs):
 		@wraps(func)
 		def wrapper(*args, **kwargs):
@@ -648,9 +630,7 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 	def _outgoing_nvdaVersion(self) -> str:
 		return versionInfo.version_detailed
 
-	@attributeReceiver(GenericAttribute.NVDA_VERSION, defaultValue="0.0.0")
-	def _incoming_nvdaVersion(self, value: str) -> str:
-		return value
+	_incoming_nvdaVersion = AttributeReceiver(GenericAttribute.NVDA_VERSION, defaultValue="0.0.0")
 
 	def _get_nvdaVersion(self) -> str:
 		return self._getRemoteAttributeValueWithFallback(GenericAttribute.NVDA_VERSION)
@@ -659,9 +639,7 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 	def _outgoing_rdAccessVersion(self) -> str:
 		return addon.version
 
-	@attributeReceiver(GenericAttribute.RD_ACCESS_VERSION, defaultValue="0.0")
-	def _incoming_rdAccessVersion(self, value: str) -> str:
-		return value
+	_incoming_rdAccessVersion = AttributeReceiver(GenericAttribute.RD_ACCESS_VERSION, defaultValue="0.0")
 
 	def _get_rdAccessVersion(self) -> str:
 		return self._getRemoteAttributeValueWithFallback(GenericAttribute.RD_ACCESS_VERSION)

--- a/addon/lib/protocol/__init__.py
+++ b/addon/lib/protocol/__init__.py
@@ -12,7 +12,7 @@ from abc import abstractmethod
 from collections import defaultdict
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
-from enum import Enum
+from enum import StrEnum
 from fnmatch import fnmatch
 from functools import partial, update_wrapper, wraps
 from typing import (
@@ -59,25 +59,26 @@ __all__ = [
 ]
 
 addon: addonHandler.Addon = addonHandler.getCodeAddon()
-SETTING_ATTRIBUTE_PREFIX = b"setting_"
+SETTING_ATTRIBUTE_PREFIX = "setting_"
 
 
-class GenericAttribute(bytes, Enum):
-	TIME_SINCE_INPUT = b"timeSinceInput"
-	SUPPORTED_SETTINGS = b"supportedSettings"
-	NVDA_VERSION = b"nvdaVersion"
-	RD_ACCESS_VERSION = b"rdAccessVersion"
+class GenericAttribute(StrEnum):
+	TIME_SINCE_INPUT = "timeSinceInput"
+	SUPPORTED_SETTINGS = "supportedSettings"
+	NVDA_VERSION = "nvdaVersion"
+	RD_ACCESS_VERSION = "rdAccessVersion"
+	PROTOCOL_VERSION = "protocolVersion"
 
 
 CommandT = GenericCommand | SpeechCommand | BrailleCommand
-AttributeT = GenericAttribute | SpeechAttribute | BrailleAttribute | bytes
+AttributeT = str
 # Handler functions are stored unbound; the first parameter is the RemoteProtocolHandler instance.
 # It is typed as Any because typing it precisely would make subclass methods (whose self is the
 # subclass) unassignable due to parameter contravariance.
 CommandHandlerFuncT = Callable[[Any, bytes], None]
 # Attribute handler functions vary in arity: catch-all handlers receive the concrete attribute as an
 # extra argument and senders may take additional (keyword) arguments.
-AttributeFetcherT = Callable[..., bytes]
+AttributeFetcherT = Callable[..., Any]
 AttributeReceiverFuncT = Callable[..., Any]
 DefaultValueGetterT = Callable[[Any, AttributeT], Any]
 AttributeValueUpdateCallbackT = Callable[[Any, AttributeT, Any], None]
@@ -123,11 +124,11 @@ def commandHandler(command: CommandT):
 
 
 class AttributeHandler[AttributeHandlerFuncT: Callable](HandlerDecoratorBase[AttributeHandlerFuncT]):
-	_attribute: AttributeT = b""
+	_attribute: AttributeT = ""
 
 	@property
 	def _isCatchAll(self) -> bool:
-		return b"*" in self._attribute
+		return "*" in self._attribute
 
 	def __init__(self, attribute: AttributeT, func: AttributeHandlerFuncT):
 		super().__init__(func)
@@ -344,10 +345,10 @@ class AttributeValueProcessor(AttributeHandlerStore[AttributeReceiver]):
 		self._valueTimes[attribute] = time.perf_counter()
 		self._submitAttributeUpdateCallback(attribute, value)
 
-	def __call__(self, attribute: AttributeT, rawValue: bytes):
+	def __call__(self, attribute: AttributeT, value: Any):
 		log.debug(f"Getting handler on {self!r} to process attribute {attribute!r}")
 		handler = self._getRawHandler(attribute)
-		value = handler(self._getOwner(), attribute, rawValue)
+		value = handler(self._getOwner(), attribute, value)
 		log.debug(f"Handler on {self!r} returned value {value!r} for attribute {attribute!r}")
 		self.setAttributeRequestPending(attribute, False)
 		self.setValue(attribute, value)
@@ -432,31 +433,34 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 
 	@commandHandler(GenericCommand.ATTRIBUTE)
 	def _command_attribute(self, payload: bytes):
-		attribute, rawValue = payload[1:].split(ATTRIBUTE_SEPARATOR, 1)
-		log.debug(f"Handling attribute {attribute!r} on {self!r}, value {rawValue!r}")
-		if not rawValue:
+		messageType, kwargs = legacy.decodeCommandPayload(
+			self.driverType,
+			GenericCommand.ATTRIBUTE,
+			payload,
+		)
+		attribute = kwargs["attribute"]
+		if messageType is RdMessageType.ATTRIBUTE_REQUEST:
 			log.debug(f"No value sent for attribute {attribute!r} on {self!r}, expecting a reply")
 			self._attributeSenderStore(attribute)
 		else:
-			log.debug(
-				f"Value of length {len(rawValue)} sent for attribute {attribute!r} "
-				f"on {self!r}, direction incoming",
-			)
-			self._attributeValueProcessor(attribute, rawValue)
+			log.debug(f"Value sent for attribute {attribute!r} on {self!r}, direction incoming")
+			self._attributeValueProcessor(attribute, kwargs["value"])
 
 	@abstractmethod
-	def _incoming_setting(self, attribute: AttributeT, payLoad: bytes):
+	def _incoming_setting(self, attribute: AttributeT, value: Any):
 		raise NotImplementedError
 
-	def writeMessage(self, command: CommandT, payload: bytes = b""):
+	def writeMessage(self, command: CommandT | int, payload: bytes = b""):
 		self._dev.write(legacy.packFrame(self.driverType, command, payload))
 
-	def setRemoteAttribute(self, attribute: AttributeT, value: bytes):
-		log.debug(f"Setting remote attribute {attribute!r} to raw value {value!r}")
-		return self.writeMessage(
-			GenericCommand.ATTRIBUTE,
-			ATTRIBUTE_SEPARATOR + attribute + ATTRIBUTE_SEPARATOR + value,
+	def setRemoteAttribute(self, attribute: AttributeT, value: Any):
+		log.debug(f"Setting remote attribute {attribute!r} to value {value!r}")
+		command, payload = legacy.encodeCommandPayload(
+			self.driverType,
+			RdMessageType.ATTRIBUTE_VALUE,
+			{"attribute": attribute, "value": value},
 		)
+		return self.writeMessage(command, payload)
 
 	def requestRemoteAttribute(self, attribute: AttributeT):
 		if self._attributeValueProcessor.isAttributeRequestPending(attribute):
@@ -464,10 +468,12 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 			return
 		log.debug(f"Requesting remote attribute {attribute!r}")
 		self._attributeValueProcessor.setAttributeRequestPending(attribute)
-		self.writeMessage(
-			GenericCommand.ATTRIBUTE,
-			ATTRIBUTE_SEPARATOR + attribute + ATTRIBUTE_SEPARATOR,
+		command, payload = legacy.encodeCommandPayload(
+			self.driverType,
+			RdMessageType.ATTRIBUTE_REQUEST,
+			{"attribute": attribute},
 		)
+		self.writeMessage(command, payload)
 
 	def _safeWait(self, predicate: Callable[[], bool], timeout: float | None = None):
 		if timeout is None:
@@ -553,23 +559,23 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 		return False
 
 	@attributeSender(GenericAttribute.NVDA_VERSION)
-	def _outgoing_nvdaVersion(self) -> bytes:
-		return versionInfo.version_detailed.encode()
+	def _outgoing_nvdaVersion(self) -> str:
+		return versionInfo.version_detailed
 
 	@attributeReceiver(GenericAttribute.NVDA_VERSION, defaultValue="0.0.0")
-	def _incoming_nvdaVersion(self, payload: bytes) -> str:
-		return payload.decode()
+	def _incoming_nvdaVersion(self, value: str) -> str:
+		return value
 
 	def _get_nvdaVersion(self) -> str:
 		return self._getRemoteAttributeValueWithFallback(GenericAttribute.NVDA_VERSION)
 
 	@attributeSender(GenericAttribute.RD_ACCESS_VERSION)
-	def _outgoing_rdAccessVersion(self) -> bytes:
-		return addon.version.encode()
+	def _outgoing_rdAccessVersion(self) -> str:
+		return addon.version
 
 	@attributeReceiver(GenericAttribute.RD_ACCESS_VERSION, defaultValue="0.0")
-	def _incoming_rdAccessVersion(self, payload: bytes) -> str:
-		return payload.decode()
+	def _incoming_rdAccessVersion(self, value: str) -> str:
+		return value
 
 	def _get_rdAccessVersion(self) -> str:
 		return self._getRemoteAttributeValueWithFallback(GenericAttribute.RD_ACCESS_VERSION)

--- a/addon/lib/protocol/__init__.py
+++ b/addon/lib/protocol/__init__.py
@@ -12,7 +12,7 @@ from abc import abstractmethod
 from collections import defaultdict
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
-from enum import Enum, IntEnum
+from enum import Enum
 from fnmatch import fnmatch
 from functools import partial, update_wrapper, wraps
 from typing import (
@@ -27,22 +27,39 @@ from baseObject import AutoPropertyObject
 from hwIo.base import IoBase
 from logHandler import log
 
+from . import legacy
 from ._restrictedUnpickling import restrictedLoads
 from .braille import BrailleAttribute, BrailleCommand
+from .legacy import ATTRIBUTE_SEPARATOR, MSG_XOFF, MSG_XON, GenericCommand
+from .messages import PROTOCOL_VERSION, DriverType, RdMessageType
 from .speech import SpeechAttribute, SpeechCommand
 
+__all__ = [
+	"ATTRIBUTE_SEPARATOR",
+	"MSG_XOFF",
+	"MSG_XON",
+	"PROTOCOL_VERSION",
+	"SETTING_ATTRIBUTE_PREFIX",
+	"AttributeT",
+	"BrailleAttribute",
+	"BrailleCommand",
+	"CommandT",
+	"DriverType",
+	"GenericAttribute",
+	"GenericCommand",
+	"RdMessageType",
+	"RemoteProtocolHandler",
+	"SpeechAttribute",
+	"SpeechCommand",
+	"attributeReceiver",
+	"attributeSender",
+	"commandHandler",
+	"legacy",
+	"restrictedLoads",
+]
+
 addon: addonHandler.Addon = addonHandler.getCodeAddon()
-ATTRIBUTE_SEPARATOR = b"`"
 SETTING_ATTRIBUTE_PREFIX = b"setting_"
-
-
-class DriverType(IntEnum):
-	SPEECH = ord(b"S")
-	BRAILLE = ord(b"B")
-
-
-class GenericCommand(IntEnum):
-	ATTRIBUTE = ord(b"@")
 
 
 class GenericAttribute(bytes, Enum):
@@ -432,13 +449,7 @@ class RemoteProtocolHandler[IoTypeT: IoBase](AutoPropertyObject):
 		raise NotImplementedError
 
 	def writeMessage(self, command: CommandT, payload: bytes = b""):
-		data = bytes((
-			self.driverType,
-			command,
-			*len(payload).to_bytes(length=2, byteorder=sys.byteorder, signed=False),
-			*payload,
-		))
-		self._dev.write(data)
+		self._dev.write(legacy.packFrame(self.driverType, command, payload))
 
 	def setRemoteAttribute(self, attribute: AttributeT, value: bytes):
 		log.debug(f"Setting remote attribute {attribute!r} to raw value {value!r}")

--- a/addon/lib/protocol/braille.py
+++ b/addon/lib/protocol/braille.py
@@ -21,6 +21,9 @@ class BrailleAttribute(bytes, Enum):
 	OBJECT_GESTURE_MAP = b"_gestureMap"
 
 
+GESTURE_FIELDS = ("source", "id", "routingIndex", "model", "dots", "space")
+
+
 class BrailleInputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
 	def __init__(
 		self,

--- a/addon/lib/protocol/braille.py
+++ b/addon/lib/protocol/braille.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Leonard de Ruijter <alderuijter@gmail.com>
 # License: GNU General Public License version 2.0
 
-from enum import Enum, IntEnum
+from enum import IntEnum, StrEnum
 
 import braille
 import brailleInput
@@ -13,12 +13,12 @@ class BrailleCommand(IntEnum):
 	EXECUTE_GESTURE = ord(b"G")
 
 
-class BrailleAttribute(bytes, Enum):
-	NUM_CELLS = b"numCells"
-	NUM_COLS = b"numCols"
-	NUM_ROWS = b"numRows"
-	GESTURE_MAP = b"gestureMap"
-	OBJECT_GESTURE_MAP = b"_gestureMap"
+class BrailleAttribute(StrEnum):
+	NUM_CELLS = "numCells"
+	NUM_COLS = "numCols"
+	NUM_ROWS = "numRows"
+	GESTURE_MAP = "gestureMap"
+	OBJECT_GESTURE_MAP = "_gestureMap"
 
 
 GESTURE_FIELDS = ("source", "id", "routingIndex", "model", "dots", "space")

--- a/addon/lib/protocol/legacy.py
+++ b/addon/lib/protocol/legacy.py
@@ -20,6 +20,8 @@ from collections.abc import Callable
 from enum import IntEnum
 from typing import Any
 
+from baseObject import AutoPropertyObject
+
 from ._restrictedUnpickling import restrictedLoads
 from .braille import GESTURE_FIELDS, BrailleCommand, BrailleInputGesture
 from .messages import DriverType, RdMessageType
@@ -154,7 +156,10 @@ def decodeAttributeValue(attribute: str, payload: bytes) -> Any:
 	for name, _encode, decode in _ATTRIBUTE_BYTE_CODECS:
 		if attribute == name:
 			return decode(payload)
-	return restrictedLoads(payload)
+	value = restrictedLoads(payload)
+	if isinstance(value, AutoPropertyObject):
+		value.invalidateCache()
+	return value
 
 
 def encodeCommandPayload(

--- a/addon/lib/protocol/legacy.py
+++ b/addon/lib/protocol/legacy.py
@@ -1,0 +1,207 @@
+# RDAccess: Remote Desktop Accessibility for NVDA
+# Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
+# License: GNU General Public License version 2.0
+
+"""Legacy (protocol v1) wire format codecs.
+
+Protocol v1 frames messages as ``[driverType:1][command:1][payloadLen:2 LE][payload]``
+with pickled payloads for non-trivial values. This module translates between those
+byte formats and the value-based messages (:class:`RdMessageType` plus kwargs) used
+by the rest of the protocol package, so a single dispatch path serves both the legacy
+and the JSON Lines stack. Payloads are unpickled through the allowlist-restricted
+unpickler only.
+"""
+
+from __future__ import annotations
+
+import pickle
+import sys
+from collections.abc import Callable
+from enum import IntEnum
+from typing import Any
+
+from ._restrictedUnpickling import restrictedLoads
+from .braille import GESTURE_FIELDS, BrailleCommand, BrailleInputGesture
+from .messages import DriverType, RdMessageType
+from .speech import SpeechCommand
+
+__all__ = [
+	"ATTRIBUTE_SEPARATOR",
+	"MSG_XOFF",
+	"MSG_XON",
+	"DriverType",
+	"GenericCommand",
+	"decodeAttributeValue",
+	"decodeCommandPayload",
+	"encodeAttributeValue",
+	"encodeCommandPayload",
+	"packFrame",
+	"restrictedLoads",
+]
+
+ATTRIBUTE_SEPARATOR = b"`"
+MSG_XON = 0x11
+MSG_XOFF = 0x13
+
+
+class GenericCommand(IntEnum):
+	ATTRIBUTE = ord(b"@")
+
+
+def dumps(obj: Any) -> bytes:
+	return pickle.dumps(obj, protocol=4)
+
+
+def packFrame(driverType: int, command: int, payload: bytes = b"") -> bytes:
+	return bytes((
+		driverType,
+		command,
+		*len(payload).to_bytes(length=2, byteorder=sys.byteorder, signed=False),
+		*payload,
+	))
+
+
+def _decodeKwargs(payload: bytes) -> dict[str, Any]:
+	kwargs = restrictedLoads(payload)
+	if not isinstance(kwargs, dict):
+		raise ValueError(f"Expected pickled kwargs, got {kwargs!r}")
+	return kwargs
+
+
+def _encodeBrailleInput(payload: dict[str, Any]) -> bytes:
+	return dumps(BrailleInputGesture(**payload))
+
+
+def _decodeBrailleInput(payload: bytes) -> dict[str, Any]:
+	gesture = restrictedLoads(payload)
+	if not isinstance(gesture, BrailleInputGesture):
+		raise ValueError(f"Expected a pickled BrailleInputGesture, got {gesture!r}")
+	return {field: getattr(gesture, field, None) for field in GESTURE_FIELDS}
+
+
+_PAYLOAD_CODECS: dict[
+	RdMessageType,
+	tuple[Callable[[dict[str, Any]], bytes], Callable[[bytes], dict[str, Any]]],
+] = {
+	RdMessageType.SPEAK: (
+		lambda p: dumps(p["sequence"]),
+		lambda b: {"sequence": restrictedLoads(b)},
+	),
+	RdMessageType.CANCEL: (lambda _p: b"", lambda _b: {}),
+	RdMessageType.PAUSE_SPEECH: (
+		lambda p: bool(p["switch"]).to_bytes(length=1, byteorder=sys.byteorder),
+		lambda b: {"switch": bool(b[0])},
+	),
+	RdMessageType.INDEX: (
+		lambda p: int(p["index"]).to_bytes(length=2, byteorder=sys.byteorder, signed=False),
+		lambda b: {"index": int.from_bytes(b, byteorder=sys.byteorder, signed=False)},
+	),
+	RdMessageType.TONE: (dumps, _decodeKwargs),
+	RdMessageType.WAVE: (dumps, _decodeKwargs),
+	RdMessageType.DISPLAY: (
+		lambda p: bytes(p["cells"]),
+		lambda b: {"cells": list(b)},
+	),
+	RdMessageType.BRAILLE_INPUT: (_encodeBrailleInput, _decodeBrailleInput),
+}
+
+_COMMAND_TO_MESSAGE: dict[DriverType, dict[int, RdMessageType]] = {
+	DriverType.SPEECH: {
+		SpeechCommand.SPEAK: RdMessageType.SPEAK,
+		SpeechCommand.CANCEL: RdMessageType.CANCEL,
+		SpeechCommand.PAUSE: RdMessageType.PAUSE_SPEECH,
+		SpeechCommand.INDEX_REACHED: RdMessageType.INDEX,
+		SpeechCommand.BEEP: RdMessageType.TONE,
+		SpeechCommand.PLAY_WAVE_FILE: RdMessageType.WAVE,
+	},
+	DriverType.BRAILLE: {
+		BrailleCommand.DISPLAY: RdMessageType.DISPLAY,
+		BrailleCommand.EXECUTE_GESTURE: RdMessageType.BRAILLE_INPUT,
+	},
+}
+_MESSAGE_TO_COMMAND: dict[DriverType, dict[RdMessageType, int]] = {
+	driverType: {msgType: command for command, msgType in mapping.items()}
+	for driverType, mapping in _COMMAND_TO_MESSAGE.items()
+}
+
+
+def _intCodec(length: int) -> tuple[Callable[[Any], bytes], Callable[[bytes], int]]:
+	return (
+		lambda value: int(value).to_bytes(length=length, byteorder=sys.byteorder, signed=False),
+		lambda payload: int.from_bytes(payload, byteorder=sys.byteorder, signed=False),
+	)
+
+
+_ATTRIBUTE_BYTE_CODECS: tuple[tuple[str, Callable[[Any], bytes], Callable[[bytes], Any]], ...] = (
+	("nvdaVersion", lambda value: str(value).encode(), lambda payload: payload.decode()),
+	("rdAccessVersion", lambda value: str(value).encode(), lambda payload: payload.decode()),
+	("protocolVersion", *_intCodec(1)),
+	("timeSinceInput", *_intCodec(4)),
+	("numCells", *_intCodec(1)),
+	("numCols", *_intCodec(1)),
+	("numRows", *_intCodec(1)),
+)
+
+
+def encodeAttributeValue(attribute: str, value: Any) -> bytes:
+	for name, encode, _decode in _ATTRIBUTE_BYTE_CODECS:
+		if attribute == name:
+			return encode(value)
+	return dumps(value)
+
+
+def decodeAttributeValue(attribute: str, payload: bytes) -> Any:
+	for name, _encode, decode in _ATTRIBUTE_BYTE_CODECS:
+		if attribute == name:
+			return decode(payload)
+	return restrictedLoads(payload)
+
+
+def encodeCommandPayload(
+	driverType: DriverType,
+	messageType: RdMessageType,
+	payload: dict[str, Any],
+) -> tuple[int, bytes]:
+	"""Translate a value-based message into a legacy ``(command, payload)`` pair."""
+	if messageType is RdMessageType.ATTRIBUTE_REQUEST:
+		attribute: str = payload["attribute"]
+		return (
+			GenericCommand.ATTRIBUTE,
+			ATTRIBUTE_SEPARATOR + attribute.encode("ASCII") + ATTRIBUTE_SEPARATOR,
+		)
+	if messageType is RdMessageType.ATTRIBUTE_VALUE:
+		attribute = payload["attribute"]
+		return (
+			GenericCommand.ATTRIBUTE,
+			ATTRIBUTE_SEPARATOR
+			+ attribute.encode("ASCII")
+			+ ATTRIBUTE_SEPARATOR
+			+ encodeAttributeValue(attribute, payload["value"]),
+		)
+	command = _MESSAGE_TO_COMMAND[DriverType(driverType)].get(messageType)
+	if command is None:
+		raise ValueError(f"Message type {messageType!r} has no legacy command for {driverType!r}")
+	encode, _decode = _PAYLOAD_CODECS[messageType]
+	return (command, encode(payload))
+
+
+def decodeCommandPayload(
+	driverType: DriverType,
+	command: int,
+	payload: bytes,
+) -> tuple[RdMessageType, dict[str, Any]]:
+	"""Translate a legacy frame's command byte and payload into a value-based message."""
+	if command == GenericCommand.ATTRIBUTE:
+		attribute, rawValue = payload[1:].split(ATTRIBUTE_SEPARATOR, 1)
+		name = attribute.decode("ASCII")
+		if not rawValue:
+			return (RdMessageType.ATTRIBUTE_REQUEST, {"attribute": name})
+		return (
+			RdMessageType.ATTRIBUTE_VALUE,
+			{"attribute": name, "value": decodeAttributeValue(name, rawValue)},
+		)
+	messageType = _COMMAND_TO_MESSAGE[DriverType(driverType)].get(command)
+	if messageType is None:
+		raise ValueError(f"Command {command!r} unknown for {driverType!r}")
+	_encode, decode = _PAYLOAD_CODECS[messageType]
+	return (messageType, decode(payload))

--- a/addon/lib/protocol/legacy.py
+++ b/addon/lib/protocol/legacy.py
@@ -23,27 +23,11 @@ from typing import Any
 from baseObject import AutoPropertyObject
 
 from ._restrictedUnpickling import restrictedLoads
-from .braille import GESTURE_FIELDS, BrailleCommand, BrailleInputGesture
-from .messages import DriverType, RdMessageType
+from .braille import GESTURE_FIELDS, BrailleAttribute, BrailleCommand, BrailleInputGesture
+from .messages import DriverType, GenericAttribute, RdMessageType
 from .speech import SpeechCommand
 
-__all__ = [
-	"ATTRIBUTE_SEPARATOR",
-	"MSG_XOFF",
-	"MSG_XON",
-	"DriverType",
-	"GenericCommand",
-	"decodeAttributeValue",
-	"decodeCommandPayload",
-	"encodeAttributeValue",
-	"encodeCommandPayload",
-	"packFrame",
-	"restrictedLoads",
-]
-
 ATTRIBUTE_SEPARATOR = b"`"
-MSG_XON = 0x11
-MSG_XOFF = 0x13
 
 
 class GenericCommand(IntEnum):
@@ -54,6 +38,13 @@ def dumps(obj: Any) -> bytes:
 	return pickle.dumps(obj, protocol=4)
 
 
+def loads(payload: bytes) -> Any:
+	value = restrictedLoads(payload)
+	if isinstance(value, AutoPropertyObject):
+		value.invalidateCache()
+	return value
+
+
 def packFrame(driverType: int, command: int, payload: bytes = b"") -> bytes:
 	return bytes((
 		driverType,
@@ -61,6 +52,17 @@ def packFrame(driverType: int, command: int, payload: bytes = b"") -> bytes:
 		*len(payload).to_bytes(length=2, byteorder=sys.byteorder, signed=False),
 		*payload,
 	))
+
+
+def parseFrame(message: bytes) -> tuple[int, bytes, bytes] | None:
+	"""Parse one frame; returns ``(command, payload, rest)``, or ``None`` when incomplete."""
+	if len(message) < 4:
+		return None
+	expectedLength = int.from_bytes(message[2:4], sys.byteorder)
+	endOfPayload = 4 + expectedLength
+	if len(message) < endOfPayload:
+		return None
+	return (message[1], message[4:endOfPayload], message[endOfPayload:])
 
 
 def _decodeKwargs(payload: bytes) -> dict[str, Any]:
@@ -134,32 +136,34 @@ def _intCodec(length: int) -> tuple[Callable[[Any], bytes], Callable[[bytes], in
 	)
 
 
-_ATTRIBUTE_BYTE_CODECS: tuple[tuple[str, Callable[[Any], bytes], Callable[[bytes], Any]], ...] = (
-	("nvdaVersion", lambda value: str(value).encode(), lambda payload: payload.decode()),
-	("rdAccessVersion", lambda value: str(value).encode(), lambda payload: payload.decode()),
-	("protocolVersion", *_intCodec(1)),
-	("timeSinceInput", *_intCodec(4)),
-	("numCells", *_intCodec(1)),
-	("numCols", *_intCodec(1)),
-	("numRows", *_intCodec(1)),
+_strCodec: tuple[Callable[[Any], bytes], Callable[[bytes], Any]] = (
+	lambda value: str(value).encode(),
+	lambda payload: payload.decode(),
 )
+
+_ATTRIBUTE_BYTE_CODECS: dict[str, tuple[Callable[[Any], bytes], Callable[[bytes], Any]]] = {
+	GenericAttribute.NVDA_VERSION: _strCodec,
+	GenericAttribute.RD_ACCESS_VERSION: _strCodec,
+	GenericAttribute.PROTOCOL_VERSION: _intCodec(1),
+	GenericAttribute.TIME_SINCE_INPUT: _intCodec(4),
+	BrailleAttribute.NUM_CELLS: _intCodec(1),
+	BrailleAttribute.NUM_COLS: _intCodec(1),
+	BrailleAttribute.NUM_ROWS: _intCodec(1),
+}
 
 
 def encodeAttributeValue(attribute: str, value: Any) -> bytes:
-	for name, encode, _decode in _ATTRIBUTE_BYTE_CODECS:
-		if attribute == name:
-			return encode(value)
+	codec = _ATTRIBUTE_BYTE_CODECS.get(attribute)
+	if codec is not None:
+		return codec[0](value)
 	return dumps(value)
 
 
 def decodeAttributeValue(attribute: str, payload: bytes) -> Any:
-	for name, _encode, decode in _ATTRIBUTE_BYTE_CODECS:
-		if attribute == name:
-			return decode(payload)
-	value = restrictedLoads(payload)
-	if isinstance(value, AutoPropertyObject):
-		value.invalidateCache()
-	return value
+	codec = _ATTRIBUTE_BYTE_CODECS.get(attribute)
+	if codec is not None:
+		return codec[1](payload)
+	return loads(payload)
 
 
 def encodeCommandPayload(

--- a/addon/lib/protocol/messages.py
+++ b/addon/lib/protocol/messages.py
@@ -11,9 +11,14 @@ Message type values marked as mirrored must stay identical to NVDA core's
 
 from __future__ import annotations
 
-from enum import StrEnum
+from enum import IntEnum, StrEnum
 
 PROTOCOL_VERSION: int = 2
+
+
+class DriverType(IntEnum):
+	SPEECH = ord(b"S")
+	BRAILLE = ord(b"B")
 
 
 class RdMessageType(StrEnum):

--- a/addon/lib/protocol/messages.py
+++ b/addon/lib/protocol/messages.py
@@ -15,6 +15,10 @@ from enum import IntEnum, StrEnum
 
 PROTOCOL_VERSION: int = 2
 
+# rd_pipe transport flow control bytes, sent outside any message framing.
+MSG_XON = 0x11
+MSG_XOFF = 0x13
+
 
 class DriverType(IntEnum):
 	SPEECH = ord(b"S")
@@ -25,6 +29,14 @@ CHANNEL_NAMES: dict[DriverType, str] = {
 	DriverType.SPEECH: "NVDA-SPEECH",
 	DriverType.BRAILLE: "NVDA-BRAILLE",
 }
+
+
+class GenericAttribute(StrEnum):
+	TIME_SINCE_INPUT = "timeSinceInput"
+	SUPPORTED_SETTINGS = "supportedSettings"
+	NVDA_VERSION = "nvdaVersion"
+	RD_ACCESS_VERSION = "rdAccessVersion"
+	PROTOCOL_VERSION = "protocolVersion"
 
 
 class RdMessageType(StrEnum):

--- a/addon/lib/protocol/messages.py
+++ b/addon/lib/protocol/messages.py
@@ -1,0 +1,34 @@
+# RDAccess: Remote Desktop Accessibility for NVDA
+# Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
+# License: GNU General Public License version 2.0
+
+"""Message catalog for protocol v2 (JSON Lines).
+
+Message type values marked as mirrored must stay identical to NVDA core's
+``_remoteClient.protocol.RemoteMessageType``; conformance tests in
+``tests/test_serializerConformance.py`` enforce this.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+PROTOCOL_VERSION: int = 2
+
+
+class RdMessageType(StrEnum):
+	# Mirrored from RemoteMessageType
+	PROTOCOL_VERSION = "protocol_version"
+	PING = "ping"
+	SPEAK = "speak"
+	CANCEL = "cancel"
+	PAUSE_SPEECH = "pause_speech"
+	TONE = "tone"
+	WAVE = "wave"
+	INDEX = "index"
+	DISPLAY = "display"
+	BRAILLE_INPUT = "braille_input"
+
+	# RDAccess-specific
+	ATTRIBUTE_REQUEST = "attribute_request"
+	ATTRIBUTE_VALUE = "attribute_value"

--- a/addon/lib/protocol/messages.py
+++ b/addon/lib/protocol/messages.py
@@ -21,6 +21,12 @@ class DriverType(IntEnum):
 	BRAILLE = ord(b"B")
 
 
+CHANNEL_NAMES: dict[DriverType, str] = {
+	DriverType.SPEECH: "NVDA-SPEECH",
+	DriverType.BRAILLE: "NVDA-BRAILLE",
+}
+
+
 class RdMessageType(StrEnum):
 	# Mirrored from RemoteMessageType
 	PROTOCOL_VERSION = "protocol_version"

--- a/addon/lib/protocol/serializer.py
+++ b/addon/lib/protocol/serializer.py
@@ -30,10 +30,14 @@ from baseObject import AutoPropertyObject
 from logHandler import log
 from synthDriverHandler import VoiceInfo
 
-from .braille import GESTURE_FIELDS, BrailleInputGesture
-from .messages import RdMessageType
+from .braille import BrailleAttribute
+from .messages import GenericAttribute, RdMessageType
+from .speech import SpeechAttribute
 
 JSONDict = dict[str, Any]
+
+_SPEAK_TYPE = RdMessageType.SPEAK.value
+_ATTRIBUTE_VALUE_TYPE = RdMessageType.ATTRIBUTE_VALUE.value
 
 SEQUENCE_CLASSES = (
 	speech.commands.SynthCommand,
@@ -64,14 +68,10 @@ class RdAccessJSONEncoder(json.JSONEncoder):
 			]
 		if isinstance(o, inputCore.GlobalGestureMap):
 			return [o.__class__.__name__, o.export()]
-		if isinstance(o, BrailleInputGesture):
-			return [BrailleInputGesture.__name__, {field: getattr(o, field) for field in GESTURE_FIELDS}]
 		if isinstance(o, type) and issubclass(o, speech.commands.SpeechCommand):
 			return o.__name__
-		if isinstance(o, frozenset):
-			if all(isinstance(item, type) for item in o):
-				return sorted(item.__name__ for item in o)
-			return sorted(o)
+		if isinstance(o, frozenset) and all(isinstance(item, type) for item in o):
+			return sorted(item.__name__ for item in o)
 		return super().default(o)
 
 
@@ -95,7 +95,7 @@ def _asSequence(dct: JSONDict) -> JSONDict:
 	Behavioral clone of ``_remoteClient.serializer.asSequence``: unknown or disallowed
 	class names are logged and skipped, reconstruction bypasses ``__init__``.
 	"""
-	if not ("type" in dct and dct["type"] == RdMessageType.SPEAK.value and "sequence" in dct):
+	if not ("type" in dct and dct["type"] == _SPEAK_TYPE and "sequence" in dct):
 		return dct
 	sequence = []
 	for item in dct["sequence"]:
@@ -153,9 +153,9 @@ def _decodeGestureMap(value: Any) -> inputCore.GlobalGestureMap | None:
 
 
 ATTRIBUTE_DECODERS: tuple[tuple[str, Callable[[Any], Any]], ...] = (
-	("supportedSettings", _decodeSupportedSettings),
-	("supportedCommands", _decodeSupportedCommands),
-	("gestureMap", _decodeGestureMap),
+	(GenericAttribute.SUPPORTED_SETTINGS, _decodeSupportedSettings),
+	(SpeechAttribute.SUPPORTED_COMMANDS, _decodeSupportedCommands),
+	(BrailleAttribute.GESTURE_MAP, _decodeGestureMap),
 	("available*s", _decodeAvailableValues),
 )
 
@@ -167,17 +167,19 @@ def decodeAttributeValue(attribute: str, value: Any) -> Any:
 	return value
 
 
+_encoder = RdAccessJSONEncoder()
+_decoder = json.JSONDecoder(object_hook=_asSequence)
+
+
 class RdJSONSerializer:
 	SEP: bytes = b"\n"
 
 	def serialize(self, type: str | None = None, **obj: Any) -> bytes:
-		if type is not None and isinstance(type, RdMessageType):
-			type = type.value
 		obj["type"] = type
-		return json.dumps(obj, cls=RdAccessJSONEncoder).encode("UTF-8") + self.SEP
+		return _encoder.encode(obj).encode("UTF-8") + self.SEP
 
 	def deserialize(self, data: bytes) -> JSONDict:
-		obj = json.loads(data, object_hook=_asSequence)
-		if isinstance(obj, dict) and obj.get("type") == RdMessageType.ATTRIBUTE_VALUE.value:
+		obj = _decoder.decode(data.decode("UTF-8"))
+		if isinstance(obj, dict) and obj.get("type") == _ATTRIBUTE_VALUE_TYPE:
 			obj["value"] = decodeAttributeValue(obj.get("attribute", ""), obj.get("value"))
 		return obj

--- a/addon/lib/protocol/serializer.py
+++ b/addon/lib/protocol/serializer.py
@@ -1,0 +1,185 @@
+# RDAccess: Remote Desktop Accessibility for NVDA
+# Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
+# License: GNU General Public License version 2.0
+
+"""JSON Lines serializer for protocol v2.
+
+The wire format follows NVDA core's ``_remoteClient.serializer``: one UTF-8 encoded
+JSON object per line with a mandatory ``type`` field. Speech sequences encode as
+``[ClassName, __dict__]`` pairs, byte-for-byte identical to NVDA Remote Access;
+conformance tests in ``tests/test_serializerConformance.py`` enforce this.
+
+RDAccess-specific attribute values (driver settings, parameter infos, gesture maps,
+speech command class sets) extend the same ``[ClassName, dict]`` convention and are
+decoded against explicit per-attribute allowlists.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import OrderedDict
+from collections.abc import Callable
+from fnmatch import fnmatchcase
+from typing import Any
+
+import inputCore
+import speech.commands
+from autoSettingsUtils.driverSetting import BooleanDriverSetting, DriverSetting, NumericDriverSetting
+from autoSettingsUtils.utils import StringParameterInfo
+from baseObject import AutoPropertyObject
+from logHandler import log
+from synthDriverHandler import VoiceInfo
+
+from .braille import BrailleInputGesture
+from .messages import RdMessageType
+
+JSONDict = dict[str, Any]
+
+SEQUENCE_CLASSES = (
+	speech.commands.SynthCommand,
+	speech.commands.EndUtteranceCommand,
+)
+
+_SETTING_CLASSES: dict[str, type] = {
+	cls.__name__: cls for cls in (DriverSetting, NumericDriverSetting, BooleanDriverSetting)
+}
+_PARAMETER_INFO_CLASSES: dict[str, type] = {cls.__name__: cls for cls in (StringParameterInfo, VoiceInfo)}
+
+_GESTURE_FIELDS = ("source", "id", "routingIndex", "model", "dots", "space")
+
+
+def _isSubclassOrInstance(unknown: Any, possible: type | tuple[type, ...]) -> bool:
+	try:
+		return issubclass(unknown, possible)
+	except TypeError:
+		return isinstance(unknown, possible)
+
+
+class RdAccessJSONEncoder(json.JSONEncoder):
+	def default(self, o: Any) -> Any:
+		if _isSubclassOrInstance(o, SEQUENCE_CLASSES):
+			return [o.__class__.__name__, o.__dict__]
+		if isinstance(o, (DriverSetting, StringParameterInfo)):
+			return [
+				o.__class__.__name__,
+				{k: v for k, v in o.__dict__.items() if k != "_propertyCache"},
+			]
+		if isinstance(o, inputCore.GlobalGestureMap):
+			return [o.__class__.__name__, o.export()]
+		if isinstance(o, BrailleInputGesture):
+			return [BrailleInputGesture.__name__, {field: getattr(o, field) for field in _GESTURE_FIELDS}]
+		if isinstance(o, type) and issubclass(o, speech.commands.SpeechCommand):
+			return o.__name__
+		if isinstance(o, frozenset):
+			if all(isinstance(item, type) for item in o):
+				return sorted(item.__name__ for item in o)
+			return sorted(o)
+		return super().default(o)
+
+
+def _reconstruct(allowedClasses: dict[str, type], item: Any) -> Any:
+	if not isinstance(item, list) or len(item) != 2:
+		raise ValueError(f"Expected a [className, state] pair, got {item!r}")
+	name, state = item
+	cls: Any = allowedClasses.get(name)
+	if cls is None or not isinstance(state, dict):
+		raise ValueError(f"Cannot reconstruct {name!r} from {state!r}")
+	obj = cls.__new__(cls)
+	obj.__dict__.update(state)
+	if isinstance(obj, AutoPropertyObject):
+		obj.invalidateCache()
+	return obj
+
+
+def _asSequence(dct: JSONDict) -> JSONDict:
+	"""Object hook reconstructing speech commands in ``speak`` messages.
+
+	Behavioral clone of ``_remoteClient.serializer.asSequence``: unknown or disallowed
+	class names are logged and skipped, reconstruction bypasses ``__init__``.
+	"""
+	if not ("type" in dct and dct["type"] == RdMessageType.SPEAK.value and "sequence" in dct):
+		return dct
+	sequence = []
+	for item in dct["sequence"]:
+		if not isinstance(item, list):
+			sequence.append(item)
+			continue
+		name, values = item
+		cls = getattr(speech.commands, name, None)
+		if cls is None or not issubclass(cls, SEQUENCE_CLASSES):
+			log.warning(f"Unknown sequence type received: {name!r}")
+			continue
+		cls = cls.__new__(cls)
+		cls.__dict__.update(values)
+		sequence.append(cls)
+	dct["sequence"] = sequence
+	return dct
+
+
+def _decodeSupportedSettings(value: Any) -> list:
+	if not isinstance(value, list):
+		raise ValueError(f"Expected a list of settings, got {value!r}")
+	return [_reconstruct(_SETTING_CLASSES, item) for item in value]
+
+
+def _decodeAvailableValues(value: Any) -> OrderedDict:
+	if not isinstance(value, dict):
+		raise ValueError(f"Expected a mapping of parameter infos, got {value!r}")
+	return OrderedDict((key, _reconstruct(_PARAMETER_INFO_CLASSES, item)) for key, item in value.items())
+
+
+def _decodeSupportedCommands(value: Any) -> frozenset[type]:
+	commands = set()
+	for name in value:
+		cls = getattr(speech.commands, name, None)
+		if (
+			cls is None
+			or not isinstance(cls, type)
+			or cls.__module__ != speech.commands.__name__
+			or not issubclass(cls, speech.commands.SpeechCommand)
+		):
+			log.warning(f"Unknown speech command received: {name!r}")
+			continue
+		commands.add(cls)
+	return frozenset(commands)
+
+
+def _decodeGestureMap(value: Any) -> inputCore.GlobalGestureMap | None:
+	if value is None:
+		return None
+	if not isinstance(value, list) or len(value) != 2 or value[0] != inputCore.GlobalGestureMap.__name__:
+		raise ValueError(f"Cannot reconstruct a gesture map from {value!r}")
+	gestureMap = inputCore.GlobalGestureMap()
+	gestureMap.update(value[1])
+	return gestureMap
+
+
+ATTRIBUTE_DECODERS: tuple[tuple[str, Callable[[Any], Any]], ...] = (
+	("supportedSettings", _decodeSupportedSettings),
+	("supportedCommands", _decodeSupportedCommands),
+	("gestureMap", _decodeGestureMap),
+	("available*s", _decodeAvailableValues),
+)
+
+
+def decodeAttributeValue(attribute: str, value: Any) -> Any:
+	for pattern, decoder in ATTRIBUTE_DECODERS:
+		if fnmatchcase(attribute, pattern):
+			return decoder(value)
+	return value
+
+
+class RdJSONSerializer:
+	SEP: bytes = b"\n"
+
+	def serialize(self, type: str | None = None, **obj: Any) -> bytes:
+		if type is not None and isinstance(type, RdMessageType):
+			type = type.value
+		obj["type"] = type
+		return json.dumps(obj, cls=RdAccessJSONEncoder).encode("UTF-8") + self.SEP
+
+	def deserialize(self, data: bytes) -> JSONDict:
+		obj = json.loads(data, object_hook=_asSequence)
+		if isinstance(obj, dict) and obj.get("type") == RdMessageType.ATTRIBUTE_VALUE.value:
+			obj["value"] = decodeAttributeValue(obj.get("attribute", ""), obj.get("value"))
+		return obj

--- a/addon/lib/protocol/serializer.py
+++ b/addon/lib/protocol/serializer.py
@@ -30,7 +30,7 @@ from baseObject import AutoPropertyObject
 from logHandler import log
 from synthDriverHandler import VoiceInfo
 
-from .braille import BrailleInputGesture
+from .braille import GESTURE_FIELDS, BrailleInputGesture
 from .messages import RdMessageType
 
 JSONDict = dict[str, Any]
@@ -44,8 +44,6 @@ _SETTING_CLASSES: dict[str, type] = {
 	cls.__name__: cls for cls in (DriverSetting, NumericDriverSetting, BooleanDriverSetting)
 }
 _PARAMETER_INFO_CLASSES: dict[str, type] = {cls.__name__: cls for cls in (StringParameterInfo, VoiceInfo)}
-
-_GESTURE_FIELDS = ("source", "id", "routingIndex", "model", "dots", "space")
 
 
 def _isSubclassOrInstance(unknown: Any, possible: type | tuple[type, ...]) -> bool:
@@ -67,7 +65,7 @@ class RdAccessJSONEncoder(json.JSONEncoder):
 		if isinstance(o, inputCore.GlobalGestureMap):
 			return [o.__class__.__name__, o.export()]
 		if isinstance(o, BrailleInputGesture):
-			return [BrailleInputGesture.__name__, {field: getattr(o, field) for field in _GESTURE_FIELDS}]
+			return [BrailleInputGesture.__name__, {field: getattr(o, field) for field in GESTURE_FIELDS}]
 		if isinstance(o, type) and issubclass(o, speech.commands.SpeechCommand):
 			return o.__name__
 		if isinstance(o, frozenset):

--- a/addon/lib/protocol/speech.py
+++ b/addon/lib/protocol/speech.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Leonard de Ruijter <alderuijter@gmail.com>
 # License: GNU General Public License version 2.0
 
-from enum import Enum, IntEnum
+from enum import IntEnum, StrEnum
 
 import speech.manager
 
@@ -18,6 +18,6 @@ class SpeechCommand(IntEnum):
 	PLAY_WAVE_FILE = ord(b"W")
 
 
-class SpeechAttribute(bytes, Enum):
-	SUPPORTED_COMMANDS = b"supportedCommands"
-	LANGUAGE = b"language"
+class SpeechAttribute(StrEnum):
+	SUPPORTED_COMMANDS = "supportedCommands"
+	LANGUAGE = "language"

--- a/addon/lib/rdPipe.py
+++ b/addon/lib/rdPipe.py
@@ -17,8 +17,10 @@ import addonHandler
 from logHandler import log
 from utils.displayString import DisplayStringIntEnum
 
-COM_CLS_CHANNEL_NAMES_VALUE_BRAILLE: Final[str] = "NVDA-BRAILLE"
-COM_CLS_CHANNEL_NAMES_VALUE_SPEECH: Final[str] = "NVDA-SPEECH"
+from .protocol.messages import CHANNEL_NAMES, DriverType
+
+COM_CLS_CHANNEL_NAMES_VALUE_BRAILLE: Final[str] = CHANNEL_NAMES[DriverType.BRAILLE]
+COM_CLS_CHANNEL_NAMES_VALUE_SPEECH: Final[str] = CHANNEL_NAMES[DriverType.SPEECH]
 COM_CLASS_FOLDER: Final[str] = r"SOFTWARE\Classes\CLSID\{D1F74DC7-9FDE-45BE-9251-FA72D4064DA3}"
 CTX_MODULES_FOLDER: Final[str] = r"SOFTWARE\Citrix\ICA Client\Engine\Configuration\Advanced\Modules"
 CTX_RD_PIPE_FOLDER: Final[str] = os.path.join(CTX_MODULES_FOLDER, "DVCPlugin_RdPipe")

--- a/addon/synthDrivers/remote.py
+++ b/addon/synthDrivers/remote.py
@@ -106,16 +106,18 @@ class remoteSynthDriver(driver.RemoteDriver, synthDriverHandler.SynthDriver):
 		except OSError:
 			log.warning("Error pausing speech", exc_info=True)
 
-	@protocol.attributeReceiver(protocol.SpeechAttribute.SUPPORTED_COMMANDS, defaultValue=frozenset())
-	def _incoming_supportedCommands(self, value: frozenset) -> frozenset:
-		return value
+	_incoming_supportedCommands = protocol.AttributeReceiver(
+		protocol.SpeechAttribute.SUPPORTED_COMMANDS,
+		defaultValue=frozenset(),
+	)
 
 	def _get_supportedCommands(self):
 		return self._getRemoteAttributeValueWithFallback(protocol.SpeechAttribute.SUPPORTED_COMMANDS)
 
-	@protocol.attributeReceiver(protocol.SpeechAttribute.LANGUAGE, defaultValue=getLanguage())
-	def _incoming_language(self, value: str | None) -> str | None:
-		return value
+	_incoming_language = protocol.AttributeReceiver(
+		protocol.SpeechAttribute.LANGUAGE,
+		defaultValue=getLanguage(),
+	)
 
 	def _get_language(self):
 		return self._getRemoteAttributeValueWithFallback(protocol.SpeechAttribute.LANGUAGE)

--- a/addon/synthDrivers/remote.py
+++ b/addon/synthDrivers/remote.py
@@ -3,7 +3,6 @@
 # License: GNU General Public License version 2.0
 
 import os.path
-import sys
 import typing
 from collections import OrderedDict
 
@@ -16,7 +15,6 @@ from autoSettingsUtils.driverSetting import DriverSetting
 from autoSettingsUtils.utils import StringParameterInfo
 from braille import AUTOMATIC_PORT
 from extensionPoints import Action
-from hwIo import boolToByte
 from languageHandler import getLanguage
 from logHandler import log
 
@@ -68,9 +66,9 @@ class remoteSynthDriver(driver.RemoteDriver, synthDriverHandler.SynthDriver):
 		super().terminate()
 
 	def handle_decideBeep(self, **kwargs) -> bool:
-		log.debug(f"Sending BEEP command: {kwargs}")
+		log.debug(f"Sending TONE command: {kwargs}")
 		try:
-			self.writeMessage(protocol.SpeechCommand.BEEP, self._pickle(kwargs))
+			self.sendMessage(protocol.RdMessageType.TONE, **kwargs)
 		except OSError:
 			log.warning("Error calling handle_decideBeep", exc_info=True)
 			return True
@@ -78,9 +76,9 @@ class remoteSynthDriver(driver.RemoteDriver, synthDriverHandler.SynthDriver):
 
 	def handle_decidePlayWaveFile(self, **kwargs) -> bool:
 		kwargs["fileName"] = os.path.relpath(kwargs["fileName"], globalVars.appDir)
-		log.debug(f"Sending PLAY_WAVE_FILE command: {kwargs}")
+		log.debug(f"Sending WAVE command: {kwargs}")
 		try:
-			self.writeMessage(protocol.SpeechCommand.PLAY_WAVE_FILE, self._pickle(kwargs))
+			self.sendMessage(protocol.RdMessageType.WAVE, **kwargs)
 		except OSError:
 			log.warning("Error calling handle_decidePlayWaveFile", exc_info=True)
 			return True
@@ -91,20 +89,20 @@ class remoteSynthDriver(driver.RemoteDriver, synthDriverHandler.SynthDriver):
 
 	def speak(self, speechSequence):
 		try:
-			self.writeMessage(protocol.SpeechCommand.SPEAK, self._pickle(speechSequence))
+			self.sendMessage(protocol.RdMessageType.SPEAK, sequence=speechSequence)
 		except OSError:
 			log.error("Error speaking", exc_info=True)
 			self._handleRemoteDisconnect()
 
 	def cancel(self):
 		try:
-			self.writeMessage(protocol.SpeechCommand.CANCEL)
+			self.sendMessage(protocol.RdMessageType.CANCEL)
 		except OSError:
 			log.warning("Error cancelling speech", exc_info=True)
 
 	def pause(self, switch):
 		try:
-			self.writeMessage(protocol.SpeechCommand.PAUSE, boolToByte(switch))
+			self.sendMessage(protocol.RdMessageType.PAUSE_SPEECH, switch=switch)
 		except OSError:
 			log.warning("Error pausing speech", exc_info=True)
 
@@ -122,14 +120,11 @@ class remoteSynthDriver(driver.RemoteDriver, synthDriverHandler.SynthDriver):
 	def _get_language(self):
 		return self._getRemoteAttributeValueWithFallback(protocol.SpeechAttribute.LANGUAGE)
 
-	@protocol.commandHandler(protocol.SpeechCommand.INDEX_REACHED)
-	def _command_indexReached(self, incomingPayload: bytes):
-		assert len(incomingPayload) == 2
-		index = int.from_bytes(incomingPayload, sys.byteorder)
+	@protocol.commandHandler(protocol.RdMessageType.INDEX)
+	def _command_indexReached(self, index: int):
 		if index:
 			synthDriverHandler.synthIndexReached.notify(synth=self, index=index)
 		else:
-			assert index == 0
 			synthDriverHandler.synthDoneSpeaking.notify(synth=self)
 
 	def _handleRemoteDriverChange(self):

--- a/addon/synthDrivers/remote.py
+++ b/addon/synthDrivers/remote.py
@@ -109,17 +109,15 @@ class remoteSynthDriver(driver.RemoteDriver, synthDriverHandler.SynthDriver):
 			log.warning("Error pausing speech", exc_info=True)
 
 	@protocol.attributeReceiver(protocol.SpeechAttribute.SUPPORTED_COMMANDS, defaultValue=frozenset())
-	def _incoming_supportedCommands(self, payLoad: bytes) -> frozenset:
-		assert len(payLoad) > 0
-		return self._unpickle(payLoad)
+	def _incoming_supportedCommands(self, value: frozenset) -> frozenset:
+		return value
 
 	def _get_supportedCommands(self):
 		return self._getRemoteAttributeValueWithFallback(protocol.SpeechAttribute.SUPPORTED_COMMANDS)
 
 	@protocol.attributeReceiver(protocol.SpeechAttribute.LANGUAGE, defaultValue=getLanguage())
-	def _incoming_language(self, payload: bytes) -> str | None:
-		assert len(payload) > 0
-		return self._unpickle(payload)
+	def _incoming_language(self, value: str | None) -> str | None:
+		return value
 
 	def _get_language(self):
 		return self._getRemoteAttributeValueWithFallback(protocol.SpeechAttribute.LANGUAGE)

--- a/buildVars.py
+++ b/buildVars.py
@@ -30,7 +30,7 @@ addon_info = AddonInfo(
 		+ "Citrix Workspace, Parallels RAS and VMware Horizon",
 	),
 	# version
-	addon_version="1.7.2",
+	addon_version="2.0.0",
 	# Brief changelog for this version
 	# Translators: what's new content for the add-on version to be shown in the add-on store
 	addon_changelog=_(""),

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,10 @@ This enables a user experience where managing a remote system feels as seamless 
 
 ## Changelog
 
+### Version 1.8
+
+* The wire protocol now uses JSON Lines messages modeled on NVDA's built-in Remote Access protocol, replacing pickle-based serialization. Both ends negotiate the format automatically; connections with older RDAccess versions transparently keep using the previous protocol.
+
 ### Version 1.7.1
 
 * Hopefully fixed a bug in rd_pipe that caused the wrong virtual channel to be created.

--- a/tests/_fakes.py
+++ b/tests/_fakes.py
@@ -86,3 +86,13 @@ def buildMessage(driverType: int, command: int, payload: bytes = b"") -> bytes:
 		*len(payload).to_bytes(length=2, byteorder=sys.byteorder, signed=False),
 		*payload,
 	))
+
+
+def speakFrame(sequence: list) -> bytes:
+	"""Legacy SPEAK frame as a v1 speech peer would send it."""
+	command, payload = protocol.legacy.encodeCommandPayload(
+		protocol.DriverType.SPEECH,
+		protocol.RdMessageType.SPEAK,
+		{"sequence": sequence},
+	)
+	return buildMessage(protocol.DriverType.SPEECH, command, payload)

--- a/tests/_fakes.py
+++ b/tests/_fakes.py
@@ -74,7 +74,7 @@ class FakeHandlerBase(protocol.RemoteProtocolHandler):
 	def _onReadError(self, error: int) -> bool:
 		return False
 
-	def _incoming_setting(self, attribute: protocol.AttributeT, payLoad: bytes):
+	def _incoming_setting(self, attribute: protocol.AttributeT, value: Any):
 		raise NotImplementedError
 
 

--- a/tests/_nvdaRemote.py
+++ b/tests/_nvdaRemote.py
@@ -1,0 +1,41 @@
+# RDAccess: Remote Desktop Accessibility for NVDA
+# Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
+# License: GNU General Public License version 2.0
+
+"""Loads NVDA core's Remote Access protocol modules from the sibling NVDA source checkout.
+
+``_remoteClient/__init__.py`` pulls in wx and NVDA config, so ``serializer.py`` and
+``protocol.py`` are loaded directly by file path, outside their package. Their imports
+(``speech.commands``, ``logHandler``) resolve against the stubs installed by :mod:`tests._stubs`.
+
+Conformance tests compare RDAccess's serializer output against these modules, so they fail
+as soon as the NVDA Remote wire protocol drifts.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from types import ModuleType
+
+from . import _NVDA_SOURCE
+
+_REMOTE_CLIENT_DIR = _NVDA_SOURCE / "_remoteClient"
+
+
+def _loadModule(fileName: str, moduleName: str) -> ModuleType:
+	if moduleName in sys.modules:
+		return sys.modules[moduleName]
+	path = _REMOTE_CLIENT_DIR / fileName
+	if not path.is_file():
+		raise RuntimeError(f"Expected NVDA Remote Access module at {path}")
+	spec = importlib.util.spec_from_file_location(moduleName, path)
+	assert spec is not None and spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	sys.modules[moduleName] = module
+	spec.loader.exec_module(module)
+	return module
+
+
+protocol = _loadModule("protocol.py", "_nvdaRemoteProtocol")
+serializer = _loadModule("serializer.py", "_nvdaRemoteSerializer")

--- a/tests/_stubs.py
+++ b/tests/_stubs.py
@@ -299,5 +299,8 @@ def _installInputCoreStub() -> None:
 		def update(self, entries: Any):
 			self._map.update(entries)
 
+		def export(self) -> dict:
+			return {section: dict(scripts) for section, scripts in self._map.items()}
+
 	_setStubIdentity(GlobalGestureMap, "inputCore")
 	inputCore.GlobalGestureMap = GlobalGestureMap

--- a/tests/_stubs.py
+++ b/tests/_stubs.py
@@ -170,32 +170,59 @@ def _installSpeechCommandsStub(speech: types.ModuleType) -> None:
 	class SpeechCommand:
 		pass
 
-	class IndexCommand(SpeechCommand):
+	class SynthCommand(SpeechCommand):
+		pass
+
+	class IndexCommand(SynthCommand):
 		def __init__(self, index: int):
 			self.index = index
 
 		def __eq__(self, other: Any) -> bool:
 			return type(self) is type(other) and self.index == other.index
 
-	class PitchCommand(SpeechCommand):
+	class SynthParamCommand(SynthCommand):
+		pass
+
+	class BaseProsodyCommand(SynthParamCommand):
+		pass
+
+	class PitchCommand(BaseProsodyCommand):
 		def __init__(self, offset: int = 0):
 			self.offset = offset
 
 		def __eq__(self, other: Any) -> bool:
 			return type(self) is type(other) and self.offset == other.offset
 
+	class BreakCommand(SynthCommand):
+		def __init__(self, time: int = 0):
+			self.time = time
+
+		def __eq__(self, other: Any) -> bool:
+			return type(self) is type(other) and self.time == other.time
+
+	class EndUtteranceCommand(SpeechCommand):
+		def __eq__(self, other: Any) -> bool:
+			return type(self) is type(other)
+
 	class NotASpeechCommand:
 		"""Exists in speech.commands but is not a SpeechCommand subclass; used to test that the
 		dynamic find_class rule for speech.commands rejects it.
 		"""
 
-	for cls in (SpeechCommand, IndexCommand, PitchCommand, NotASpeechCommand):
+	stubClasses = (
+		SpeechCommand,
+		SynthCommand,
+		IndexCommand,
+		SynthParamCommand,
+		BaseProsodyCommand,
+		PitchCommand,
+		BreakCommand,
+		EndUtteranceCommand,
+		NotASpeechCommand,
+	)
+	for cls in stubClasses:
 		_setStubIdentity(cls, "speech.commands")
-
-	speechCommands.SpeechCommand = SpeechCommand
-	speechCommands.IndexCommand = IndexCommand
-	speechCommands.PitchCommand = PitchCommand
-	speechCommands.NotASpeechCommand = NotASpeechCommand
+		setattr(speechCommands, cls.__name__, cls)
 
 
 def _installDriverSettingAndSynthVoiceStubs() -> None:

--- a/tests/test_attributeHandling.py
+++ b/tests/test_attributeHandling.py
@@ -10,17 +10,28 @@ import time
 import unittest
 
 from lib import protocol
+from lib.protocol import legacy
 
 from tests._fakes import FakeHandlerBase, buildMessage
 
 # ---------------------------------------------------------------------------
-# Helper: build a raw ATTRIBUTE payload as the wire expects it.
+# Helpers: build raw ATTRIBUTE wire messages as a v1 peer would send them.
 # ---------------------------------------------------------------------------
 
 
-def _attrPayload(attribute: bytes, value: bytes = b"") -> bytes:
-	"""Return the payload bytes that _command_attribute parses."""
-	return protocol.ATTRIBUTE_SEPARATOR + attribute + protocol.ATTRIBUTE_SEPARATOR + value
+def _attrRequest(attribute: str) -> bytes:
+	payload = protocol.ATTRIBUTE_SEPARATOR + attribute.encode("ASCII") + protocol.ATTRIBUTE_SEPARATOR
+	return buildMessage(protocol.DriverType.SPEECH, protocol.GenericCommand.ATTRIBUTE, payload)
+
+
+def _attrPush(attribute: str, value) -> bytes:
+	payload = (
+		protocol.ATTRIBUTE_SEPARATOR
+		+ attribute.encode("ASCII")
+		+ protocol.ATTRIBUTE_SEPARATOR
+		+ legacy.encodeAttributeValue(attribute, value)
+	)
+	return buildMessage(protocol.DriverType.SPEECH, protocol.GenericCommand.ATTRIBUTE, payload)
 
 
 # ---------------------------------------------------------------------------
@@ -30,8 +41,8 @@ def _attrPayload(attribute: bytes, value: bytes = b"") -> bytes:
 
 class LanguageSender(FakeHandlerBase):
 	@protocol.attributeSender(protocol.SpeechAttribute.LANGUAGE)
-	def _outgoing_language(self) -> bytes:
-		return b"nl"
+	def _outgoing_language(self) -> str:
+		return "nl"
 
 
 class TestRequestPath(unittest.TestCase):
@@ -41,24 +52,19 @@ class TestRequestPath(unittest.TestCase):
 
 	def test_request_triggers_reply_write(self):
 		"""Empty-value ATTRIBUTE message causes setRemoteAttribute to be called."""
-		msg = buildMessage(
-			protocol.DriverType.SPEECH,
-			protocol.GenericCommand.ATTRIBUTE,
-			_attrPayload(protocol.SpeechAttribute.LANGUAGE),
-		)
-		self.handler._onReceive(msg)
+		self.handler._onReceive(_attrRequest(protocol.SpeechAttribute.LANGUAGE))
 		self.assertEqual(len(self.handler._dev.writes), 1)
 
 	def test_reply_payload_contains_attribute_and_value(self):
-		"""The written reply embeds ``language`` and ``nl`` in its payload."""
-		msg = buildMessage(
-			protocol.DriverType.SPEECH,
-			protocol.GenericCommand.ATTRIBUTE,
-			_attrPayload(protocol.SpeechAttribute.LANGUAGE),
-		)
-		self.handler._onReceive(msg)
+		"""The written reply embeds ``language`` and the encoded value in its payload."""
+		self.handler._onReceive(_attrRequest(protocol.SpeechAttribute.LANGUAGE))
 		written = self.handler._dev.writes[0]
-		expected_payload = _attrPayload(protocol.SpeechAttribute.LANGUAGE, b"nl")
+		expected_payload = (
+			protocol.ATTRIBUTE_SEPARATOR
+			+ b"language"
+			+ protocol.ATTRIBUTE_SEPARATOR
+			+ legacy.encodeAttributeValue(protocol.SpeechAttribute.LANGUAGE, "nl")
+		)
 		# The written message is a full wire message; the payload starts at byte 4.
 		self.assertIn(expected_payload, written)
 
@@ -70,8 +76,8 @@ class TestRequestPath(unittest.TestCase):
 
 class LanguageReceiver(FakeHandlerBase):
 	@protocol.attributeReceiver(protocol.SpeechAttribute.LANGUAGE, defaultValue="en")
-	def _incoming_language(self, payload: bytes) -> str:
-		return payload.decode()
+	def _incoming_language(self, value: str) -> str:
+		return value
 
 
 class TestPushPath(unittest.TestCase):
@@ -80,12 +86,7 @@ class TestPushPath(unittest.TestCase):
 		self.addCleanup(self.handler.terminate)
 
 	def test_push_stores_decoded_value(self):
-		msg = buildMessage(
-			protocol.DriverType.SPEECH,
-			protocol.GenericCommand.ATTRIBUTE,
-			_attrPayload(protocol.SpeechAttribute.LANGUAGE, b"nl"),
-		)
-		self.handler._onReceive(msg)
+		self.handler._onReceive(_attrPush(protocol.SpeechAttribute.LANGUAGE, "nl"))
 		value = self.handler._attributeValueProcessor.getValue(
 			protocol.SpeechAttribute.LANGUAGE,
 			fallBackToDefault=False,
@@ -94,12 +95,7 @@ class TestPushPath(unittest.TestCase):
 
 	def test_push_no_writes(self):
 		"""An incoming push must not generate a reply write."""
-		msg = buildMessage(
-			protocol.DriverType.SPEECH,
-			protocol.GenericCommand.ATTRIBUTE,
-			_attrPayload(protocol.SpeechAttribute.LANGUAGE, b"nl"),
-		)
-		self.handler._onReceive(msg)
+		self.handler._onReceive(_attrPush(protocol.SpeechAttribute.LANGUAGE, "nl"))
 		self.assertEqual(self.handler._dev.writes, [])
 
 
@@ -114,8 +110,8 @@ class LanguageReceiverWithCallback(FakeHandlerBase):
 		super().__init__()
 
 	@protocol.attributeReceiver(protocol.SpeechAttribute.LANGUAGE, defaultValue="en")
-	def _incoming_language(self, payload: bytes) -> str:
-		return payload.decode()
+	def _incoming_language(self, value: str) -> str:
+		return value
 
 	@_incoming_language.updateCallback
 	def _cb_language(self, attribute: protocol.AttributeT, value: object) -> None:
@@ -128,12 +124,7 @@ class TestUpdateCallback(unittest.TestCase):
 		self.addCleanup(self.handler.terminate)
 
 	def test_callback_fires_on_push(self):
-		msg = buildMessage(
-			protocol.DriverType.SPEECH,
-			protocol.GenericCommand.ATTRIBUTE,
-			_attrPayload(protocol.SpeechAttribute.LANGUAGE, b"nl"),
-		)
-		self.handler._onReceive(msg)
+		self.handler._onReceive(_attrPush(protocol.SpeechAttribute.LANGUAGE, "nl"))
 		self.assertEqual(len(self.handler.callback_calls), 1)
 		attr, val = self.handler.callback_calls[0]
 		self.assertEqual(attr, protocol.SpeechAttribute.LANGUAGE)
@@ -148,12 +139,7 @@ class TestUpdateCallback(unittest.TestCase):
 
 	def test_callback_records_correct_value_inside_body(self):
 		"""Callback body sees exactly the value that was pushed, not stale state."""
-		msg = buildMessage(
-			protocol.DriverType.SPEECH,
-			protocol.GenericCommand.ATTRIBUTE,
-			_attrPayload(protocol.SpeechAttribute.LANGUAGE, b"fr"),
-		)
-		self.handler._onReceive(msg)
+		self.handler._onReceive(_attrPush(protocol.SpeechAttribute.LANGUAGE, "fr"))
 		self.assertEqual(self.handler.callback_calls[-1], (protocol.SpeechAttribute.LANGUAGE, "fr"))
 
 
@@ -209,8 +195,8 @@ _SENTINEL = object()
 
 class LanguageReceiverWithGetter(FakeHandlerBase):
 	@protocol.attributeReceiver(protocol.SpeechAttribute.LANGUAGE)
-	def _incoming_language(self, payload: bytes) -> object:
-		return payload.decode()
+	def _incoming_language(self, value: object) -> object:
+		return value
 
 	@_incoming_language.defaultValueGetter
 	def _default_language(self, _attribute: protocol.AttributeT) -> object:
@@ -238,7 +224,7 @@ class TestDefaultValueGetter(unittest.TestCase):
 class TestFactoryValidation(unittest.TestCase):
 	def test_both_defaultValue_and_defaultValueGetter_raises(self):
 		with self.assertRaises(ValueError):
-			protocol.attributeReceiver(b"x", defaultValue=1, defaultValueGetter=lambda _s, _a: 2)
+			protocol.attributeReceiver("x", defaultValue=1, defaultValueGetter=lambda _s, _a: 2)
 
 
 # ---------------------------------------------------------------------------
@@ -248,13 +234,13 @@ class TestFactoryValidation(unittest.TestCase):
 
 class WildcardSettingReceiver(FakeHandlerBase):
 	def __init__(self):
-		self.wildcard_calls: list[tuple[bytes, bytes]] = []
+		self.wildcard_calls: list[tuple[str, object]] = []
 		super().__init__()
 
-	@protocol.attributeReceiver(protocol.SETTING_ATTRIBUTE_PREFIX + b"*")
-	def _incoming_setting(self, attribute: protocol.AttributeT, payload: bytes) -> bytes:  # type: ignore[override]
-		self.wildcard_calls.append((bytes(attribute), payload))
-		return payload
+	@protocol.attributeReceiver(protocol.SETTING_ATTRIBUTE_PREFIX + "*")
+	def _incoming_setting(self, attribute: protocol.AttributeT, value: object) -> object:  # type: ignore[override]
+		self.wildcard_calls.append((attribute, value))
+		return value
 
 
 class TestWildcardReceiver(unittest.TestCase):
@@ -263,26 +249,16 @@ class TestWildcardReceiver(unittest.TestCase):
 		self.addCleanup(self.handler.terminate)
 
 	def test_wildcard_invoked_with_concrete_attribute(self):
-		msg = buildMessage(
-			protocol.DriverType.SPEECH,
-			protocol.GenericCommand.ATTRIBUTE,
-			_attrPayload(b"setting_rate", b"50"),
-		)
-		self.handler._onReceive(msg)
+		self.handler._onReceive(_attrPush("setting_rate", 50))
 		self.assertEqual(len(self.handler.wildcard_calls), 1)
-		attr, payload = self.handler.wildcard_calls[0]
-		self.assertEqual(attr, b"setting_rate")
-		self.assertEqual(payload, b"50")
+		attr, value = self.handler.wildcard_calls[0]
+		self.assertEqual(attr, "setting_rate")
+		self.assertEqual(value, 50)
 
 	def test_value_stored_under_concrete_attribute(self):
-		msg = buildMessage(
-			protocol.DriverType.SPEECH,
-			protocol.GenericCommand.ATTRIBUTE,
-			_attrPayload(b"setting_rate", b"50"),
-		)
-		self.handler._onReceive(msg)
-		val = self.handler._attributeValueProcessor.getValue(b"setting_rate", fallBackToDefault=False)
-		self.assertEqual(val, b"50")
+		self.handler._onReceive(_attrPush("setting_rate", 50))
+		val = self.handler._attributeValueProcessor.getValue("setting_rate", fallBackToDefault=False)
+		self.assertEqual(val, 50)
 
 
 # ---------------------------------------------------------------------------
@@ -292,19 +268,19 @@ class TestWildcardReceiver(unittest.TestCase):
 
 class ExactBeatWildcardReceiver(FakeHandlerBase):
 	def __init__(self):
-		self.wildcard_calls: list[tuple[bytes, bytes]] = []
-		self.exact_calls: list[bytes] = []
+		self.wildcard_calls: list[tuple[str, object]] = []
+		self.exact_calls: list[object] = []
 		super().__init__()
 
-	@protocol.attributeReceiver(protocol.SETTING_ATTRIBUTE_PREFIX + b"*")
-	def _incoming_setting(self, attribute: protocol.AttributeT, payload: bytes) -> bytes:  # type: ignore[override]
-		self.wildcard_calls.append((bytes(attribute), payload))
-		return payload
+	@protocol.attributeReceiver(protocol.SETTING_ATTRIBUTE_PREFIX + "*")
+	def _incoming_setting(self, attribute: protocol.AttributeT, value: object) -> object:  # type: ignore[override]
+		self.wildcard_calls.append((attribute, value))
+		return value
 
-	@protocol.attributeReceiver(b"setting_voice", defaultValue=None)
-	def _incoming_setting_voice(self, payload: bytes) -> bytes:
-		self.exact_calls.append(payload)
-		return payload
+	@protocol.attributeReceiver("setting_voice", defaultValue=None)
+	def _incoming_setting_voice(self, value: object) -> object:
+		self.exact_calls.append(value)
+		return value
 
 
 class TestExactBeatsWildcard(unittest.TestCase):
@@ -313,30 +289,15 @@ class TestExactBeatsWildcard(unittest.TestCase):
 		self.addCleanup(self.handler.terminate)
 
 	def test_exact_handler_invoked_for_setting_voice(self):
-		msg = buildMessage(
-			protocol.DriverType.SPEECH,
-			protocol.GenericCommand.ATTRIBUTE,
-			_attrPayload(b"setting_voice", b"David"),
-		)
-		self.handler._onReceive(msg)
-		self.assertEqual(self.handler.exact_calls, [b"David"])
+		self.handler._onReceive(_attrPush("setting_voice", "David"))
+		self.assertEqual(self.handler.exact_calls, ["David"])
 
 	def test_wildcard_not_invoked_for_setting_voice(self):
-		msg = buildMessage(
-			protocol.DriverType.SPEECH,
-			protocol.GenericCommand.ATTRIBUTE,
-			_attrPayload(b"setting_voice", b"David"),
-		)
-		self.handler._onReceive(msg)
+		self.handler._onReceive(_attrPush("setting_voice", "David"))
 		self.assertEqual(self.handler.wildcard_calls, [])
 
 	def test_wildcard_still_handles_other_settings(self):
-		msg = buildMessage(
-			protocol.DriverType.SPEECH,
-			protocol.GenericCommand.ATTRIBUTE,
-			_attrPayload(b"setting_rate", b"75"),
-		)
-		self.handler._onReceive(msg)
+		self.handler._onReceive(_attrPush("setting_rate", 75))
 		self.assertEqual(len(self.handler.wildcard_calls), 1)
 		self.assertEqual(self.handler.exact_calls, [])
 
@@ -348,13 +309,13 @@ class TestExactBeatsWildcard(unittest.TestCase):
 
 class WildcardSenderHandler(FakeHandlerBase):
 	def __init__(self):
-		self.sender_calls: list[bytes] = []
+		self.sender_calls: list[str] = []
 		super().__init__()
 
-	@protocol.attributeSender(b"available*s")
-	def _outgoing_available(self, attribute: protocol.AttributeT) -> bytes:
-		self.sender_calls.append(bytes(attribute))
-		return b"data_for_" + bytes(attribute)
+	@protocol.attributeSender("available*s")
+	def _outgoing_available(self, attribute: protocol.AttributeT) -> str:
+		self.sender_calls.append(attribute)
+		return f"data_for_{attribute}"
 
 
 class TestWildcardSender(unittest.TestCase):
@@ -363,21 +324,22 @@ class TestWildcardSender(unittest.TestCase):
 		self.addCleanup(self.handler.terminate)
 
 	def test_wildcard_sender_writes_reply(self):
-		self.handler._attributeSenderStore(b"availableVoices")
+		self.handler._attributeSenderStore("availableVoices")
 		self.assertEqual(len(self.handler._dev.writes), 1)
 
 	def test_wildcard_sender_receives_concrete_attribute(self):
-		self.handler._attributeSenderStore(b"availableVoices")
-		self.assertEqual(self.handler.sender_calls, [b"availableVoices"])
+		self.handler._attributeSenderStore("availableVoices")
+		self.assertEqual(self.handler.sender_calls, ["availableVoices"])
 
 	def test_wildcard_sender_reply_contains_concrete_attribute(self):
-		self.handler._attributeSenderStore(b"availableVoices")
+		self.handler._attributeSenderStore("availableVoices")
 		written = self.handler._dev.writes[0]
 		self.assertIn(b"availableVoices", written)
 
 	def test_wildcard_sender_reply_contains_value(self):
-		self.handler._attributeSenderStore(b"availableVoices")
+		self.handler._attributeSenderStore("availableVoices")
 		written = self.handler._dev.writes[0]
+		# The value is pickled; the string's UTF-8 bytes appear inside the pickle.
 		self.assertIn(b"data_for_availableVoices", written)
 
 
@@ -400,7 +362,7 @@ class TestIsAttributeSupported(unittest.TestCase):
 
 	def test_unknown_sender_not_supported(self):
 		self.assertFalse(
-			self.handler._attributeSenderStore.isAttributeSupported(b"unknownAttribute"),
+			self.handler._attributeSenderStore.isAttributeSupported("unknownAttribute"),
 		)
 
 	def test_exact_receiver_supported(self):
@@ -412,14 +374,14 @@ class TestIsAttributeSupported(unittest.TestCase):
 
 	def test_unknown_receiver_not_supported(self):
 		self.assertFalse(
-			self.receiver_handler._attributeValueProcessor.isAttributeSupported(b"unknownAttribute"),
+			self.receiver_handler._attributeValueProcessor.isAttributeSupported("unknownAttribute"),
 		)
 
 	def test_wildcard_receiver_matched_supported(self):
 		handler = WildcardSettingReceiver()
 		self.addCleanup(handler.terminate)
 		self.assertTrue(
-			handler._attributeValueProcessor.isAttributeSupported(b"setting_pitch"),
+			handler._attributeValueProcessor.isAttributeSupported("setting_pitch"),
 		)
 
 
@@ -435,11 +397,11 @@ class TestUnknownAttributeDispatch(unittest.TestCase):
 
 	def test_unknown_receiver_raises(self):
 		with self.assertRaises(NotImplementedError):
-			self.handler._attributeValueProcessor(b"nope", b"v")
+			self.handler._attributeValueProcessor("nope", "v")
 
 	def test_unknown_sender_raises(self):
 		with self.assertRaises(NotImplementedError):
-			self.handler._attributeSenderStore(b"nope")
+			self.handler._attributeSenderStore("nope")
 
 
 # ---------------------------------------------------------------------------
@@ -532,12 +494,7 @@ class TestPendingCleared(unittest.TestCase):
 		avp.setAttributeRequestPending(protocol.SpeechAttribute.LANGUAGE)
 		self.assertTrue(avp.isAttributeRequestPending(protocol.SpeechAttribute.LANGUAGE))
 
-		msg = buildMessage(
-			protocol.DriverType.SPEECH,
-			protocol.GenericCommand.ATTRIBUTE,
-			_attrPayload(protocol.SpeechAttribute.LANGUAGE, b"nl"),
-		)
-		self.handler._onReceive(msg)
+		self.handler._onReceive(_attrPush(protocol.SpeechAttribute.LANGUAGE, "nl"))
 		self.assertFalse(avp.isAttributeRequestPending(protocol.SpeechAttribute.LANGUAGE))
 
 

--- a/tests/test_commandDispatch.py
+++ b/tests/test_commandDispatch.py
@@ -9,11 +9,22 @@ from __future__ import annotations
 import unittest
 
 from lib import protocol
+from lib.protocol import legacy
+from lib.protocol.messages import RdMessageType
 
 from tests._fakes import FakeHandlerBase, buildMessage
 
 # ATTRIBUTE_SEPARATOR is b"`" (0x60)
 _SEP = protocol.ATTRIBUTE_SEPARATOR
+
+
+def _speakFrame(sequence: list) -> bytes:
+	command, payload = legacy.encodeCommandPayload(
+		protocol.DriverType.SPEECH,
+		RdMessageType.SPEAK,
+		{"sequence": sequence},
+	)
+	return buildMessage(protocol.DriverType.SPEECH, command, payload)
 
 
 # ---------------------------------------------------------------------------
@@ -22,32 +33,32 @@ _SEP = protocol.ATTRIBUTE_SEPARATOR
 
 
 class _SpeakRecorder(FakeHandlerBase):
-	"""Records payloads delivered to the SPEAK command handler."""
+	"""Records sequences delivered to the SPEAK command handler."""
 
 	def __init__(self):
 		super().__init__()
-		self.speak_calls: list[bytes] = []
+		self.speak_calls: list[list] = []
 
-	@protocol.commandHandler(protocol.SpeechCommand.SPEAK)
-	def _command_speak(self, payload: bytes):
-		self.speak_calls.append(payload)
+	@protocol.commandHandler(RdMessageType.SPEAK)
+	def _command_speak(self, sequence: list):
+		self.speak_calls.append(sequence)
 
 
 class _MultiCommandRecorder(FakeHandlerBase):
-	"""Records payloads for SPEAK and CANCEL separately."""
+	"""Records dispatches for SPEAK and CANCEL separately."""
 
 	def __init__(self):
 		super().__init__()
-		self.speak_calls: list[bytes] = []
-		self.cancel_calls: list[bytes] = []
+		self.speak_calls: list[list] = []
+		self.cancel_calls: int = 0
 
-	@protocol.commandHandler(protocol.SpeechCommand.SPEAK)
-	def _command_speak(self, payload: bytes):
-		self.speak_calls.append(payload)
+	@protocol.commandHandler(RdMessageType.SPEAK)
+	def _command_speak(self, sequence: list):
+		self.speak_calls.append(sequence)
 
-	@protocol.commandHandler(protocol.SpeechCommand.CANCEL)
-	def _command_cancel(self, payload: bytes):
-		self.cancel_calls.append(payload)
+	@protocol.commandHandler(RdMessageType.CANCEL)
+	def _command_cancel(self):
+		self.cancel_calls += 1
 
 
 class _BaseWithCancel(FakeHandlerBase):
@@ -57,23 +68,23 @@ class _BaseWithCancel(FakeHandlerBase):
 		super().__init__()
 		self.log: list[str] = []
 
-	@protocol.commandHandler(protocol.SpeechCommand.CANCEL)
-	def _command_cancel(self, _payload: bytes):
+	@protocol.commandHandler(RdMessageType.CANCEL)
+	def _command_cancel(self):
 		self.log.append("base")
 
 
 class _SubOverridesCancel(_BaseWithCancel):
 	"""Subclass that re-decorates the same method name to record 'sub'."""
 
-	@protocol.commandHandler(protocol.SpeechCommand.CANCEL)
-	def _command_cancel(self, _payload: bytes):
+	@protocol.commandHandler(RdMessageType.CANCEL)
+	def _command_cancel(self):
 		self.log.append("sub")
 
 
 class _Sub2PlainOverride(_BaseWithCancel):
 	"""Subclass that shadows _command_cancel with a plain (undecorated) method."""
 
-	def _command_cancel(self, _payload: bytes):  # plain — not a CommandHandler descriptor
+	def _command_cancel(self):  # plain — not a CommandHandler descriptor
 		self.log.append("plain")
 
 
@@ -90,15 +101,13 @@ class TestCommandDispatchViaOnReceive(unittest.TestCase):
 		self.addCleanup(self.handler.terminate)
 
 	def test_speak_handler_called_once_with_correct_payload(self):
-		"""_onReceive routes SPEAK to the decorated handler with the full payload."""
-		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, b"hello")
-		self.handler._onReceive(msg)
-		self.assertEqual(self.handler.speak_calls, [b"hello"])
+		"""_onReceive routes SPEAK to the decorated handler with the decoded sequence."""
+		self.handler._onReceive(_speakFrame(["hello"]))
+		self.assertEqual(self.handler.speak_calls, [["hello"]])
 
 	def test_speak_handler_called_once_not_multiple_times(self):
 		"""Each message produces exactly one handler invocation."""
-		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, b"world")
-		self.handler._onReceive(msg)
+		self.handler._onReceive(_speakFrame(["world"]))
 		self.assertEqual(len(self.handler.speak_calls), 1)
 
 
@@ -110,46 +119,46 @@ class TestCommandDispatchViaStore(unittest.TestCase):
 		self.addCleanup(self.handler.terminate)
 
 	def test_direct_store_call_invokes_handler(self):
-		"""Calling the store directly with (command, payload) invokes the registered handler."""
-		self.handler._commandHandlerStore(protocol.SpeechCommand.SPEAK, b"x")
-		self.assertEqual(self.handler.speak_calls, [b"x"])
+		"""Calling the store directly with (messageType, **kwargs) invokes the registered handler."""
+		self.handler._commandHandlerStore(RdMessageType.SPEAK, sequence=["x"])
+		self.assertEqual(self.handler.speak_calls, [["x"]])
 
 
 class TestUnknownCommandRaisesNotImplementedError(unittest.TestCase):
-	"""Dispatching an unregistered command raises NotImplementedError from the store."""
+	"""Dispatching an unregistered message type raises NotImplementedError from the store."""
 
 	def setUp(self):
 		self.handler = _SpeakRecorder()
 		self.addCleanup(self.handler.terminate)
 
 	def test_unregistered_command_raises(self):
-		"""BEEP has no handler in _SpeakRecorder; the store must raise NotImplementedError."""
+		"""TONE has no handler in _SpeakRecorder; the store must raise NotImplementedError."""
 		with self.assertRaises(NotImplementedError):
-			self.handler._commandHandlerStore(protocol.SpeechCommand.BEEP, b"")
+			self.handler._commandHandlerStore(RdMessageType.TONE, hz=440.0)
 
 
 class TestMultipleCommandsRouteCorrectly(unittest.TestCase):
-	"""Multiple decorated handlers each receive only their own command."""
+	"""Multiple decorated handlers each receive only their own message type."""
 
 	def setUp(self):
 		self.handler = _MultiCommandRecorder()
 		self.addCleanup(self.handler.terminate)
 
 	def test_speak_routes_to_speak_handler(self):
-		self.handler._commandHandlerStore(protocol.SpeechCommand.SPEAK, b"speak-payload")
-		self.assertEqual(self.handler.speak_calls, [b"speak-payload"])
-		self.assertEqual(self.handler.cancel_calls, [])
+		self.handler._commandHandlerStore(RdMessageType.SPEAK, sequence=["speak-payload"])
+		self.assertEqual(self.handler.speak_calls, [["speak-payload"]])
+		self.assertEqual(self.handler.cancel_calls, 0)
 
 	def test_cancel_routes_to_cancel_handler(self):
-		self.handler._commandHandlerStore(protocol.SpeechCommand.CANCEL, b"cancel-payload")
-		self.assertEqual(self.handler.cancel_calls, [b"cancel-payload"])
+		self.handler._commandHandlerStore(RdMessageType.CANCEL)
+		self.assertEqual(self.handler.cancel_calls, 1)
 		self.assertEqual(self.handler.speak_calls, [])
 
 	def test_both_handlers_independent(self):
-		self.handler._commandHandlerStore(protocol.SpeechCommand.SPEAK, b"s")
-		self.handler._commandHandlerStore(protocol.SpeechCommand.CANCEL, b"c")
-		self.assertEqual(self.handler.speak_calls, [b"s"])
-		self.assertEqual(self.handler.cancel_calls, [b"c"])
+		self.handler._commandHandlerStore(RdMessageType.SPEAK, sequence=["s"])
+		self.handler._commandHandlerStore(RdMessageType.CANCEL)
+		self.assertEqual(self.handler.speak_calls, [["s"]])
+		self.assertEqual(self.handler.cancel_calls, 1)
 
 
 class TestSubclassDecoratorOverride(unittest.TestCase):
@@ -158,19 +167,19 @@ class TestSubclassDecoratorOverride(unittest.TestCase):
 	def test_sub_handler_recorded_not_base(self):
 		sub = _SubOverridesCancel()
 		self.addCleanup(sub.terminate)
-		sub._commandHandlerStore(protocol.SpeechCommand.CANCEL, b"")
+		sub._commandHandlerStore(RdMessageType.CANCEL)
 		self.assertEqual(sub.log, ["sub"])
 
 	def test_base_handler_still_records_base(self):
 		base = _BaseWithCancel()
 		self.addCleanup(base.terminate)
-		base._commandHandlerStore(protocol.SpeechCommand.CANCEL, b"")
+		base._commandHandlerStore(RdMessageType.CANCEL)
 		self.assertEqual(base.log, ["base"])
 
 	def test_sub_does_not_record_base(self):
 		sub = _SubOverridesCancel()
 		self.addCleanup(sub.terminate)
-		sub._commandHandlerStore(protocol.SpeechCommand.CANCEL, b"")
+		sub._commandHandlerStore(RdMessageType.CANCEL)
 		self.assertNotIn("base", sub.log)
 
 
@@ -184,7 +193,7 @@ class TestPlainOverrideUnregistersCommand(unittest.TestCase):
 		handler = _Sub2PlainOverride()
 		self.addCleanup(handler.terminate)
 		with self.assertRaises(NotImplementedError):
-			handler._commandHandlerStore(protocol.SpeechCommand.CANCEL, b"")
+			handler._commandHandlerStore(RdMessageType.CANCEL)
 
 
 class TestInstanceIsolation(unittest.TestCase):
@@ -197,20 +206,20 @@ class TestInstanceIsolation(unittest.TestCase):
 		self.addCleanup(self.b.terminate)
 
 	def test_dispatch_to_a_does_not_affect_b(self):
-		self.a._commandHandlerStore(protocol.SpeechCommand.SPEAK, b"for-a")
-		self.assertEqual(self.a.speak_calls, [b"for-a"])
+		self.a._commandHandlerStore(RdMessageType.SPEAK, sequence=["for-a"])
+		self.assertEqual(self.a.speak_calls, [["for-a"]])
 		self.assertEqual(self.b.speak_calls, [])
 
 	def test_dispatch_to_b_does_not_affect_a(self):
-		self.b._commandHandlerStore(protocol.SpeechCommand.SPEAK, b"for-b")
-		self.assertEqual(self.b.speak_calls, [b"for-b"])
+		self.b._commandHandlerStore(RdMessageType.SPEAK, sequence=["for-b"])
+		self.assertEqual(self.b.speak_calls, [["for-b"]])
 		self.assertEqual(self.a.speak_calls, [])
 
 
 class TestBuiltInAttributeHandler(unittest.TestCase):
-	"""GenericCommand.ATTRIBUTE is registered on every subclass.
+	"""ATTRIBUTE frames are normalized into attribute request/value messages.
 
-	When a peer requests NVDA_VERSION (empty rawValue), _command_attribute calls
+	When a peer requests NVDA_VERSION (empty rawValue), _handleMessage calls
 	_attributeSenderStore which invokes _outgoing_nvdaVersion, which writes the
 	version bytes back through FakeIo.  The stubbed versionInfo.version_detailed
 	is '2026.1.0-test'.
@@ -231,9 +240,9 @@ class TestBuiltInAttributeHandler(unittest.TestCase):
 		)
 
 	def test_attribute_handler_registered(self):
-		"""ATTRIBUTE command must be dispatchable without NotImplementedError."""
+		"""ATTRIBUTE frames must be dispatchable without NotImplementedError."""
 		msg = self._make_attribute_request(protocol.GenericAttribute.NVDA_VERSION)
-		# If the handler is missing this raises; we just verify it doesn't.
+		# If the handling is missing this raises; we just verify it doesn't.
 		self.handler._onReceive(msg)
 
 	def test_nvda_version_request_writes_reply(self):

--- a/tests/test_commandDispatch.py
+++ b/tests/test_commandDispatch.py
@@ -9,22 +9,12 @@ from __future__ import annotations
 import unittest
 
 from lib import protocol
-from lib.protocol import legacy
 from lib.protocol.messages import RdMessageType
 
-from tests._fakes import FakeHandlerBase, buildMessage
+from tests._fakes import FakeHandlerBase, buildMessage, speakFrame
 
 # ATTRIBUTE_SEPARATOR is b"`" (0x60)
 _SEP = protocol.ATTRIBUTE_SEPARATOR
-
-
-def _speakFrame(sequence: list) -> bytes:
-	command, payload = legacy.encodeCommandPayload(
-		protocol.DriverType.SPEECH,
-		RdMessageType.SPEAK,
-		{"sequence": sequence},
-	)
-	return buildMessage(protocol.DriverType.SPEECH, command, payload)
 
 
 # ---------------------------------------------------------------------------
@@ -102,12 +92,12 @@ class TestCommandDispatchViaOnReceive(unittest.TestCase):
 
 	def test_speak_handler_called_once_with_correct_payload(self):
 		"""_onReceive routes SPEAK to the decorated handler with the decoded sequence."""
-		self.handler._onReceive(_speakFrame(["hello"]))
+		self.handler._onReceive(speakFrame(["hello"]))
 		self.assertEqual(self.handler.speak_calls, [["hello"]])
 
 	def test_speak_handler_called_once_not_multiple_times(self):
 		"""Each message produces exactly one handler invocation."""
-		self.handler._onReceive(_speakFrame(["world"]))
+		self.handler._onReceive(speakFrame(["world"]))
 		self.assertEqual(len(self.handler.speak_calls), 1)
 
 

--- a/tests/test_commandDispatch.py
+++ b/tests/test_commandDispatch.py
@@ -220,10 +220,10 @@ class TestBuiltInAttributeHandler(unittest.TestCase):
 		self.handler = FakeHandlerBase()
 		self.addCleanup(self.handler.terminate)
 
-	def _make_attribute_request(self, attribute: bytes) -> bytes:
+	def _make_attribute_request(self, attribute: str) -> bytes:
 		"""Build an ATTRIBUTE wire message that requests (empty value) the given attribute name."""
 		# payload layout: SEP + attributeName + SEP + rawValue(empty)
-		payload = _SEP + attribute + _SEP
+		payload = _SEP + attribute.encode("ASCII") + _SEP
 		return buildMessage(
 			protocol.DriverType.SPEECH,
 			protocol.GenericCommand.ATTRIBUTE,

--- a/tests/test_dualStack.py
+++ b/tests/test_dualStack.py
@@ -1,0 +1,211 @@
+# RDAccess: Remote Desktop Accessibility for NVDA
+# Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
+# License: GNU General Public License version 2.0
+
+"""Tests for the dual-stack send-path switch and protocol version handshake.
+
+Two in-process handlers are wired write-to-receive to simulate a connection.
+The InlineExecutor in FakeHandlerBase makes all dispatch synchronous, so a
+"pump" that forwards captured writes drains the conversation deterministically.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from lib import protocol
+from lib.protocol import legacy
+from lib.protocol.messages import CHANNEL_NAMES, PROTOCOL_VERSION, RdMessageType
+
+from tests._fakes import FakeHandlerBase, buildMessage
+
+
+def _versionPushFrame(version: int) -> bytes:
+	"""Legacy-format protocolVersion attribute push, as a v2 peer sends it at connect."""
+	command, payload = legacy.encodeCommandPayload(
+		protocol.DriverType.SPEECH,
+		RdMessageType.ATTRIBUTE_VALUE,
+		{"attribute": protocol.GenericAttribute.PROTOCOL_VERSION, "value": version},
+	)
+	return buildMessage(protocol.DriverType.SPEECH, command, payload)
+
+
+class ConversingHandler(FakeHandlerBase):
+	"""Speaks both directions: records SPEAK dispatches and serves LANGUAGE."""
+
+	language = "nl"
+
+	def __init__(self):
+		self.speak_sequences: list[list] = []
+		super().__init__()
+
+	@protocol.commandHandler(RdMessageType.SPEAK)
+	def _command_speak(self, sequence: list):
+		self.speak_sequences.append(sequence)
+
+	@protocol.attributeSender(protocol.SpeechAttribute.LANGUAGE)
+	def _outgoing_language(self) -> str:
+		return self.language
+
+	@protocol.attributeReceiver(protocol.SpeechAttribute.LANGUAGE, defaultValue="en")
+	def _incoming_language(self, value: str) -> str:
+		return value
+
+
+class LegacyPinnedHandler(ConversingHandler):
+	"""Simulates a protocol v1 peer: never pushes its version and never switches."""
+
+	def _handlePeerProtocolVersionChange(self, version: int):
+		pass
+
+	def pushProtocolVersion(self):
+		pass
+
+
+def _pump(a: ConversingHandler, b: ConversingHandler, maxRounds: int = 10):
+	"""Forward captured writes between both handlers until the conversation settles."""
+	for _ in range(maxRounds):
+		aOut = a._dev.writes[:]
+		bOut = b._dev.writes[:]
+		a._dev.writes.clear()
+		b._dev.writes.clear()
+		if not aOut and not bOut:
+			return
+		for data in aOut:
+			b._onReceive(data)
+		for data in bOut:
+			a._onReceive(data)
+	raise AssertionError("Conversation did not settle")
+
+
+class TestSendPathSwitch(unittest.TestCase):
+	def setUp(self):
+		self.handler = ConversingHandler()
+		self.addCleanup(self.handler.terminate)
+
+	def test_initial_send_is_legacy(self):
+		self.handler.sendMessage(RdMessageType.SPEAK, sequence=["hi"])
+		self.assertEqual(self.handler._dev.writes[0][0], protocol.DriverType.SPEECH)
+
+	def test_legacy_version_push_switches_to_json(self):
+		self.handler._onReceive(_versionPushFrame(2))
+		self.assertTrue(self.handler._sendJson)
+		self.handler._dev.writes.clear()
+		self.handler.sendMessage(RdMessageType.SPEAK, sequence=["hi"])
+		self.assertEqual(self.handler._dev.writes[0][0:1], b"{")
+
+	def test_switch_emits_one_shot_json_handshake(self):
+		self.handler._onReceive(_versionPushFrame(2))
+		jsonWrites = [w for w in self.handler._dev.writes if w.startswith(b"{")]
+		self.assertEqual(len(jsonWrites), 1)
+		obj = self.handler._serializer.deserialize(jsonWrites[0])
+		self.assertEqual(obj["type"], RdMessageType.PROTOCOL_VERSION.value)
+		self.assertEqual(obj["version"], PROTOCOL_VERSION)
+		self.assertEqual(obj["channel"], CHANNEL_NAMES[protocol.DriverType.SPEECH])
+
+	def test_handshake_not_repeated(self):
+		self.handler._onReceive(_versionPushFrame(2))
+		self.handler._dev.writes.clear()
+		self.handler._onReceive(_versionPushFrame(2))
+		self.assertEqual(self.handler._dev.writes, [])
+
+	def test_incoming_json_line_switches_implicitly(self):
+		line = self.handler._serializer.serialize(type=RdMessageType.SPEAK, sequence=["x"])
+		self.handler._onReceive(line)
+		self.assertTrue(self.handler._sendJson)
+
+	def test_version_1_push_does_not_switch(self):
+		self.handler._onReceive(_versionPushFrame(1))
+		self.assertFalse(self.handler._sendJson)
+		self.handler._dev.writes.clear()
+		self.handler.sendMessage(RdMessageType.CANCEL)
+		self.assertEqual(self.handler._dev.writes[0][0], protocol.DriverType.SPEECH)
+
+	def test_push_protocol_version_uses_legacy_format(self):
+		self.handler.pushProtocolVersion()
+		written = self.handler._dev.writes[0]
+		self.assertEqual(written[0], protocol.DriverType.SPEECH)
+		self.assertEqual(written[1], protocol.GenericCommand.ATTRIBUTE)
+		self.assertIn(b"`protocolVersion`", written)
+
+
+class TestPeerInterop(unittest.TestCase):
+	def _connect(self, a: ConversingHandler, b: ConversingHandler):
+		a.pushProtocolVersion()
+		b.pushProtocolVersion()
+		_pump(a, b)
+
+	def test_two_v2_peers_migrate_to_json(self):
+		a = ConversingHandler()
+		self.addCleanup(a.terminate)
+		b = ConversingHandler()
+		self.addCleanup(b.terminate)
+		self._connect(a, b)
+		self.assertTrue(a._sendJson)
+		self.assertTrue(b._sendJson)
+
+		a.sendMessage(RdMessageType.SPEAK, sequence=["json speech"])
+		self.assertEqual(a._dev.writes[0][0:1], b"{")
+		_pump(a, b)
+		self.assertEqual(b.speak_sequences, [["json speech"]])
+
+	def test_two_v2_peers_attribute_roundtrip_in_json_mode(self):
+		a = ConversingHandler()
+		self.addCleanup(a.terminate)
+		b = ConversingHandler()
+		self.addCleanup(b.terminate)
+		b.language = "de"
+		self._connect(a, b)
+
+		a.requestRemoteAttribute(protocol.SpeechAttribute.LANGUAGE)
+		_pump(a, b)
+		value = a._attributeValueProcessor.getValue(
+			protocol.SpeechAttribute.LANGUAGE,
+			fallBackToDefault=False,
+		)
+		self.assertEqual(value, "de")
+
+	def test_v2_peer_with_v1_peer_stays_legacy(self):
+		new = ConversingHandler()
+		self.addCleanup(new.terminate)
+		old = LegacyPinnedHandler()
+		self.addCleanup(old.terminate)
+		self._connect(new, old)
+		self.assertFalse(new._sendJson)
+		self.assertFalse(old._sendJson)
+
+		new.sendMessage(RdMessageType.SPEAK, sequence=["legacy speech"])
+		self.assertEqual(new._dev.writes[0][0], protocol.DriverType.SPEECH)
+		_pump(new, old)
+		self.assertEqual(old.speak_sequences, [["legacy speech"]])
+
+	def test_v1_peer_speech_reaches_v2_peer(self):
+		new = ConversingHandler()
+		self.addCleanup(new.terminate)
+		old = LegacyPinnedHandler()
+		self.addCleanup(old.terminate)
+		self._connect(new, old)
+
+		old.sendMessage(RdMessageType.SPEAK, sequence=["old to new"])
+		_pump(new, old)
+		self.assertEqual(new.speak_sequences, [["old to new"]])
+
+	def test_attribute_roundtrip_with_v1_peer(self):
+		new = ConversingHandler()
+		self.addCleanup(new.terminate)
+		old = LegacyPinnedHandler()
+		self.addCleanup(old.terminate)
+		old.language = "fr"
+		self._connect(new, old)
+
+		new.requestRemoteAttribute(protocol.SpeechAttribute.LANGUAGE)
+		_pump(new, old)
+		value = new._attributeValueProcessor.getValue(
+			protocol.SpeechAttribute.LANGUAGE,
+			fallBackToDefault=False,
+		)
+		self.assertEqual(value, "fr")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_framing.py
+++ b/tests/test_framing.py
@@ -49,6 +49,13 @@ def _speakFrame(sequence: list) -> bytes:
 	return buildMessage(protocol.DriverType.SPEECH, command, payload)
 
 
+def _speakJsonLine(sequence: list) -> bytes:
+	return protocol.RemoteProtocolHandler._serializer.serialize(
+		type=RdMessageType.SPEAK,
+		sequence=sequence,
+	)
+
+
 # ---------------------------------------------------------------------------
 # 1. Complete message → handler invoked once with exact payload.
 # ---------------------------------------------------------------------------
@@ -231,6 +238,98 @@ class TestEmptyPayload(unittest.TestCase):
 		self.handler._onReceive(msg1 + msg2)
 		self.assertEqual(self.handler.cancel_calls, 1)
 		self.assertEqual(self.handler.speak_sequences, [["after"]])
+
+
+# ---------------------------------------------------------------------------
+# 7. Dual-stack sniffing: JSON lines and legacy frames on the same connection.
+# ---------------------------------------------------------------------------
+
+
+class TestDualStackSniffing(unittest.TestCase):
+	def setUp(self):
+		self.handler = SpeakCapture()
+		self.addCleanup(self.handler.terminate)
+
+	def test_json_line_dispatches(self):
+		sequence = ["json hello"]
+		self.handler._onReceive(_speakJsonLine(sequence))
+		self.assertEqual(self.handler.speak_sequences, [sequence])
+
+	def test_json_line_marks_peer_v2(self):
+		self.assertEqual(self.handler._peerProtocolVersion, 1)
+		self.handler._onReceive(_speakJsonLine(["x"]))
+		self.assertEqual(self.handler._peerProtocolVersion, protocol.PROTOCOL_VERSION)
+
+	def test_legacy_frame_does_not_mark_peer_v2(self):
+		self.handler._onReceive(_speakFrame(["x"]))
+		self.assertEqual(self.handler._peerProtocolVersion, 1)
+
+	def test_interleaved_legacy_json_legacy_in_one_receive(self):
+		data = _speakFrame(["legacy-1"]) + _speakJsonLine(["json-2"]) + _speakFrame(["legacy-3"])
+		self.handler._onReceive(data)
+		self.assertEqual(self.handler.speak_sequences, [["legacy-1"], ["json-2"], ["legacy-3"]])
+
+	def test_json_line_split_across_receives(self):
+		line = _speakJsonLine(["split json line"])
+		split = len(line) // 2
+		self.handler._onReceive(line[:split])
+		self.assertEqual(self.handler.speak_sequences, [])
+		self.handler._onReceive(line[split:])
+		self.assertEqual(self.handler.speak_sequences, [["split json line"]])
+
+	def test_split_legacy_frame_followed_by_json(self):
+		frame = _speakFrame(["legacy part"])
+		line = _speakJsonLine(["json after"])
+		split = 4 + (len(frame) - 4) // 2
+		self.handler._onReceive(frame[:split])
+		self.assertEqual(self.handler.speak_sequences, [])
+		self.handler._onReceive(frame[split:] + line)
+		self.assertEqual(self.handler.speak_sequences, [["legacy part"], ["json after"]])
+
+	def test_malformed_json_line_logged_not_raised(self):
+		self.handler._onReceive(b"{not valid json}\n")
+		self.assertEqual(self.handler.speak_sequences, [])
+
+	def test_unknown_json_message_type_dropped(self):
+		self.handler._onReceive(b'{"type": "no_such_type"}\n')
+		self.assertEqual(self.handler.speak_sequences, [])
+
+	def test_garbage_first_byte_still_raises(self):
+		with self.assertRaises(RuntimeError):
+			self.handler._onReceive(b"\x99garbage")
+
+
+class TestProtocolVersionMessage(unittest.TestCase):
+	def setUp(self):
+		self.handler = SpeakCapture()
+		self.addCleanup(self.handler.terminate)
+
+	def test_version_message_records_peer_version(self):
+		line = protocol.RemoteProtocolHandler._serializer.serialize(
+			type=RdMessageType.PROTOCOL_VERSION,
+			version=2,
+			channel="NVDA-SPEECH",
+		)
+		self.handler._onReceive(line)
+		self.assertEqual(self.handler._peerProtocolVersion, 2)
+
+	def test_channel_mismatch_rejected(self):
+		"""A braille channel handshake on a speech handler must not record anything.
+
+		The JSON line itself would mark the peer as v2, so the version must stay
+		untouched only through the explicit early return; assert on the log instead."""
+		from logHandler import log
+
+		log.records.clear()
+		self.handler._handleProtocolVersionMessage(version=2, channel="NVDA-BRAILLE")
+		self.assertEqual(self.handler._peerProtocolVersion, 1)
+		self.assertTrue(any("unexpected channel" in msg for _level, msg in log.records))
+
+	def test_ping_is_noop(self):
+		line = protocol.RemoteProtocolHandler._serializer.serialize(type=RdMessageType.PING)
+		self.handler._onReceive(line)
+		self.assertEqual(self.handler.speak_sequences, [])
+		self.assertEqual(self.handler._dev.writes, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_framing.py
+++ b/tests/test_framing.py
@@ -2,7 +2,7 @@
 # Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
 # License: GNU General Public License version 2.0
 
-"""Unit tests for RemoteProtocolHandler wire-framing (_onReceive / writeMessage)."""
+"""Unit tests for RemoteProtocolHandler wire-framing (_onReceive)."""
 
 from __future__ import annotations
 
@@ -10,10 +10,9 @@ import contextlib
 import unittest
 
 from lib import protocol
-from lib.protocol import legacy
 from lib.protocol.messages import RdMessageType
 
-from tests._fakes import FakeHandlerBase, buildMessage
+from tests._fakes import FakeHandlerBase, buildMessage, speakFrame
 
 # ---------------------------------------------------------------------------
 # Concrete handler used by all framing tests.
@@ -40,15 +39,6 @@ class SpeakCapture(FakeHandlerBase):
 		self.cancel_calls += 1
 
 
-def _speakFrame(sequence: list) -> bytes:
-	command, payload = legacy.encodeCommandPayload(
-		protocol.DriverType.SPEECH,
-		RdMessageType.SPEAK,
-		{"sequence": sequence},
-	)
-	return buildMessage(protocol.DriverType.SPEECH, command, payload)
-
-
 def _speakJsonLine(sequence: list) -> bytes:
 	return protocol.RemoteProtocolHandler._serializer.serialize(
 		type=RdMessageType.SPEAK,
@@ -68,12 +58,12 @@ class TestCompleteMessage(unittest.TestCase):
 
 	def test_single_complete_message_dispatches_once(self):
 		sequence = ["hello world"]
-		self.handler._onReceive(_speakFrame(sequence))
+		self.handler._onReceive(speakFrame(sequence))
 		self.assertEqual(self.handler.speak_sequences, [sequence])
 
 	def test_single_complete_message_exact_payload_content(self):
 		sequence = ["\x00\x01\x02\x03", "second item"]
-		self.handler._onReceive(_speakFrame(sequence))
+		self.handler._onReceive(speakFrame(sequence))
 		self.assertEqual(len(self.handler.speak_sequences), 1)
 		self.assertEqual(self.handler.speak_sequences[0], sequence)
 
@@ -91,7 +81,7 @@ class TestPartialDelivery(unittest.TestCase):
 	def test_two_way_split_after_header(self):
 		"""header + first half of payload → no dispatch; second half → dispatch once."""
 		sequence = ["abcdefghij"]
-		msg = _speakFrame(sequence)
+		msg = speakFrame(sequence)
 		# Split at byte 9 (header is 4 bytes, split in the middle of payload)
 		split = 4 + 5
 		self.handler._onReceive(msg[:split])
@@ -106,7 +96,7 @@ class TestPartialDelivery(unittest.TestCase):
 	def test_three_way_split(self):
 		"""Three chunks spanning the payload → exactly one dispatch with full payload."""
 		sequence = ["0123456789abcdef"]
-		msg = _speakFrame(sequence)
+		msg = speakFrame(sequence)
 		# All split points are strictly after the 4-byte header.
 		split1 = 4 + 4
 		split2 = 4 + 10
@@ -120,7 +110,7 @@ class TestPartialDelivery(unittest.TestCase):
 	def test_split_one_byte_before_end(self):
 		"""All but the last payload byte in the first chunk."""
 		sequence = ["xyz"]
-		msg = _speakFrame(sequence)
+		msg = speakFrame(sequence)
 		split = len(msg) - 1
 		self.handler._onReceive(msg[:split])
 		self.assertEqual(self.handler.speak_sequences, [])
@@ -141,19 +131,19 @@ class TestCoalescedMessages(unittest.TestCase):
 	def test_two_complete_messages_both_dispatched(self):
 		sequence1 = ["first"]
 		sequence2 = ["second"]
-		self.handler._onReceive(_speakFrame(sequence1) + _speakFrame(sequence2))
+		self.handler._onReceive(speakFrame(sequence1) + speakFrame(sequence2))
 		self.assertEqual(self.handler.speak_sequences, [sequence1, sequence2])
 
 	def test_three_complete_messages_all_dispatched_in_order(self):
 		sequences = [["alpha"], ["beta"], ["gamma"]]
-		msg = b"".join(_speakFrame(s) for s in sequences)
+		msg = b"".join(speakFrame(s) for s in sequences)
 		self.handler._onReceive(msg)
 		self.assertEqual(self.handler.speak_sequences, sequences)
 
 	def test_coalesced_preserves_payload_content(self):
 		sequence1 = ["\xff\xfe"]
 		sequence2 = ["\x00"]
-		self.handler._onReceive(_speakFrame(sequence1) + _speakFrame(sequence2))
+		self.handler._onReceive(speakFrame(sequence1) + speakFrame(sequence2))
 		self.assertEqual(self.handler.speak_sequences[0], sequence1)
 		self.assertEqual(self.handler.speak_sequences[1], sequence2)
 
@@ -172,8 +162,8 @@ class TestCoalescedPartial(unittest.TestCase):
 	def test_complete_plus_partial_then_remainder(self):
 		sequence1 = ["complete"]
 		sequence2 = ["partial-message-payload"]
-		msg1 = _speakFrame(sequence1)
-		msg2 = _speakFrame(sequence2)
+		msg1 = speakFrame(sequence1)
+		msg2 = speakFrame(sequence2)
 		# Split msg2 after its header, in the middle of its payload.
 		split_in_msg2 = 4 + (len(msg2) - 4) // 2
 		self.handler._onReceive(msg1 + msg2[:split_in_msg2])
@@ -185,7 +175,7 @@ class TestCoalescedPartial(unittest.TestCase):
 	def test_two_complete_then_partial_then_rest(self):
 		"""Two complete messages, then a partial, then the rest of the partial."""
 		sequences = [["one"], ["two"], ["three-is-the-long-one"]]
-		msgs = [_speakFrame(s) for s in sequences]
+		msgs = [speakFrame(s) for s in sequences]
 		split = 4 + (len(msgs[2]) - 4) // 2
 		self.handler._onReceive(msgs[0] + msgs[1] + msgs[2][:split])
 		self.assertEqual(self.handler.speak_sequences, [sequences[0], sequences[1]])
@@ -234,7 +224,7 @@ class TestEmptyPayload(unittest.TestCase):
 	def test_empty_payload_then_nonempty(self):
 		"""Empty-payload message followed by a message with payload — both dispatched."""
 		msg1 = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.CANCEL, b"")
-		msg2 = _speakFrame(["after"])
+		msg2 = speakFrame(["after"])
 		self.handler._onReceive(msg1 + msg2)
 		self.assertEqual(self.handler.cancel_calls, 1)
 		self.assertEqual(self.handler.speak_sequences, [["after"]])
@@ -261,11 +251,11 @@ class TestDualStackSniffing(unittest.TestCase):
 		self.assertEqual(self.handler._peerProtocolVersion, protocol.PROTOCOL_VERSION)
 
 	def test_legacy_frame_does_not_mark_peer_v2(self):
-		self.handler._onReceive(_speakFrame(["x"]))
+		self.handler._onReceive(speakFrame(["x"]))
 		self.assertEqual(self.handler._peerProtocolVersion, 1)
 
 	def test_interleaved_legacy_json_legacy_in_one_receive(self):
-		data = _speakFrame(["legacy-1"]) + _speakJsonLine(["json-2"]) + _speakFrame(["legacy-3"])
+		data = speakFrame(["legacy-1"]) + _speakJsonLine(["json-2"]) + speakFrame(["legacy-3"])
 		self.handler._onReceive(data)
 		self.assertEqual(self.handler.speak_sequences, [["legacy-1"], ["json-2"], ["legacy-3"]])
 
@@ -278,7 +268,7 @@ class TestDualStackSniffing(unittest.TestCase):
 		self.assertEqual(self.handler.speak_sequences, [["split json line"]])
 
 	def test_split_legacy_frame_followed_by_json(self):
-		frame = _speakFrame(["legacy part"])
+		frame = speakFrame(["legacy part"])
 		line = _speakJsonLine(["json after"])
 		split = 4 + (len(frame) - 4) // 2
 		self.handler._onReceive(frame[:split])
@@ -321,7 +311,10 @@ class TestProtocolVersionMessage(unittest.TestCase):
 		from logHandler import log
 
 		log.records.clear()
-		self.handler._handleProtocolVersionMessage(version=2, channel="NVDA-BRAILLE")
+		self.handler._handleMessage(
+			RdMessageType.PROTOCOL_VERSION,
+			{"version": 2, "channel": "NVDA-BRAILLE"},
+		)
 		self.assertEqual(self.handler._peerProtocolVersion, 1)
 		self.assertTrue(any("unexpected channel" in msg for _level, msg in log.records))
 

--- a/tests/test_framing.py
+++ b/tests/test_framing.py
@@ -329,7 +329,10 @@ class TestProtocolVersionMessage(unittest.TestCase):
 		line = protocol.RemoteProtocolHandler._serializer.serialize(type=RdMessageType.PING)
 		self.handler._onReceive(line)
 		self.assertEqual(self.handler.speak_sequences, [])
-		self.assertEqual(self.handler._dev.writes, [])
+		# The ping itself is a no-op; the only permitted write is the one-shot
+		# protocol_version handshake triggered by implicitly detecting a v2 peer.
+		for written in self.handler._dev.writes:
+			self.assertIn(b'"type": "protocol_version"', written)
 
 
 if __name__ == "__main__":

--- a/tests/test_framing.py
+++ b/tests/test_framing.py
@@ -10,6 +10,8 @@ import contextlib
 import unittest
 
 from lib import protocol
+from lib.protocol import legacy
+from lib.protocol.messages import RdMessageType
 
 from tests._fakes import FakeHandlerBase, buildMessage
 
@@ -19,18 +21,32 @@ from tests._fakes import FakeHandlerBase, buildMessage
 
 
 class SpeakCapture(FakeHandlerBase):
-	"""Records payloads delivered to the SPEAK command handler."""
+	"""Records sequences delivered to the SPEAK command handler."""
 
 	def __init__(self):
 		# Initialise the capture list before super().__init__ so it is available
 		# immediately after construction (super().__init__ is safe here — __new__
 		# has already done all decorator registration).
-		self.speak_payloads: list[bytes] = []
+		self.speak_sequences: list[list] = []
+		self.cancel_calls: int = 0
 		super().__init__()
 
-	@protocol.commandHandler(protocol.SpeechCommand.SPEAK)
-	def _on_speak(self, payload: bytes) -> None:
-		self.speak_payloads.append(payload)
+	@protocol.commandHandler(RdMessageType.SPEAK)
+	def _on_speak(self, sequence: list) -> None:
+		self.speak_sequences.append(sequence)
+
+	@protocol.commandHandler(RdMessageType.CANCEL)
+	def _on_cancel(self) -> None:
+		self.cancel_calls += 1
+
+
+def _speakFrame(sequence: list) -> bytes:
+	command, payload = legacy.encodeCommandPayload(
+		protocol.DriverType.SPEECH,
+		RdMessageType.SPEAK,
+		{"sequence": sequence},
+	)
+	return buildMessage(protocol.DriverType.SPEECH, command, payload)
 
 
 # ---------------------------------------------------------------------------
@@ -44,17 +60,15 @@ class TestCompleteMessage(unittest.TestCase):
 		self.addCleanup(self.handler.terminate)
 
 	def test_single_complete_message_dispatches_once(self):
-		payload = b"hello world"
-		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload)
-		self.handler._onReceive(msg)
-		self.assertEqual(self.handler.speak_payloads, [payload])
+		sequence = ["hello world"]
+		self.handler._onReceive(_speakFrame(sequence))
+		self.assertEqual(self.handler.speak_sequences, [sequence])
 
 	def test_single_complete_message_exact_payload_content(self):
-		payload = b"\x00\x01\x02\x03"
-		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload)
-		self.handler._onReceive(msg)
-		self.assertEqual(len(self.handler.speak_payloads), 1)
-		self.assertEqual(self.handler.speak_payloads[0], payload)
+		sequence = ["\x00\x01\x02\x03", "second item"]
+		self.handler._onReceive(_speakFrame(sequence))
+		self.assertEqual(len(self.handler.speak_sequences), 1)
+		self.assertEqual(self.handler.speak_sequences[0], sequence)
 
 
 # ---------------------------------------------------------------------------
@@ -69,42 +83,42 @@ class TestPartialDelivery(unittest.TestCase):
 
 	def test_two_way_split_after_header(self):
 		"""header + first half of payload → no dispatch; second half → dispatch once."""
-		payload = b"abcdefghij"  # 10 bytes
-		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload)
-		# Split at byte 4+5 = 9 (header is 4 bytes, split in the middle of payload)
+		sequence = ["abcdefghij"]
+		msg = _speakFrame(sequence)
+		# Split at byte 9 (header is 4 bytes, split in the middle of payload)
 		split = 4 + 5
 		self.handler._onReceive(msg[:split])
 		self.assertEqual(
-			self.handler.speak_payloads,
+			self.handler.speak_sequences,
 			[],
 			"No dispatch expected before full payload arrives",
 		)
 		self.handler._onReceive(msg[split:])
-		self.assertEqual(self.handler.speak_payloads, [payload])
+		self.assertEqual(self.handler.speak_sequences, [sequence])
 
 	def test_three_way_split(self):
 		"""Three chunks spanning the payload → exactly one dispatch with full payload."""
-		payload = b"0123456789abcdef"  # 16 bytes
-		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload)
+		sequence = ["0123456789abcdef"]
+		msg = _speakFrame(sequence)
 		# All split points are strictly after the 4-byte header.
-		split1 = 4 + 4  # header + first 4 bytes of payload
-		split2 = 4 + 10  # header + first 10 bytes of payload
+		split1 = 4 + 4
+		split2 = 4 + 10
 		self.handler._onReceive(msg[:split1])
-		self.assertEqual(self.handler.speak_payloads, [])
+		self.assertEqual(self.handler.speak_sequences, [])
 		self.handler._onReceive(msg[split1:split2])
-		self.assertEqual(self.handler.speak_payloads, [])
+		self.assertEqual(self.handler.speak_sequences, [])
 		self.handler._onReceive(msg[split2:])
-		self.assertEqual(self.handler.speak_payloads, [payload])
+		self.assertEqual(self.handler.speak_sequences, [sequence])
 
 	def test_split_one_byte_before_end(self):
 		"""All but the last payload byte in the first chunk."""
-		payload = b"xyz"
-		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload)
+		sequence = ["xyz"]
+		msg = _speakFrame(sequence)
 		split = len(msg) - 1
 		self.handler._onReceive(msg[:split])
-		self.assertEqual(self.handler.speak_payloads, [])
+		self.assertEqual(self.handler.speak_sequences, [])
 		self.handler._onReceive(msg[split:])
-		self.assertEqual(self.handler.speak_payloads, [payload])
+		self.assertEqual(self.handler.speak_sequences, [sequence])
 
 
 # ---------------------------------------------------------------------------
@@ -118,35 +132,23 @@ class TestCoalescedMessages(unittest.TestCase):
 		self.addCleanup(self.handler.terminate)
 
 	def test_two_complete_messages_both_dispatched(self):
-		payload1 = b"first"
-		payload2 = b"second"
-		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload1) + buildMessage(
-			protocol.DriverType.SPEECH,
-			protocol.SpeechCommand.SPEAK,
-			payload2,
-		)
-		self.handler._onReceive(msg)
-		self.assertEqual(self.handler.speak_payloads, [payload1, payload2])
+		sequence1 = ["first"]
+		sequence2 = ["second"]
+		self.handler._onReceive(_speakFrame(sequence1) + _speakFrame(sequence2))
+		self.assertEqual(self.handler.speak_sequences, [sequence1, sequence2])
 
 	def test_three_complete_messages_all_dispatched_in_order(self):
-		payloads = [b"alpha", b"beta", b"gamma"]
-		msg = b"".join(
-			buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, p) for p in payloads
-		)
+		sequences = [["alpha"], ["beta"], ["gamma"]]
+		msg = b"".join(_speakFrame(s) for s in sequences)
 		self.handler._onReceive(msg)
-		self.assertEqual(self.handler.speak_payloads, payloads)
+		self.assertEqual(self.handler.speak_sequences, sequences)
 
 	def test_coalesced_preserves_payload_content(self):
-		payload1 = b"\xff\xfe"
-		payload2 = b"\x00"
-		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload1) + buildMessage(
-			protocol.DriverType.SPEECH,
-			protocol.SpeechCommand.SPEAK,
-			payload2,
-		)
-		self.handler._onReceive(msg)
-		self.assertEqual(self.handler.speak_payloads[0], payload1)
-		self.assertEqual(self.handler.speak_payloads[1], payload2)
+		sequence1 = ["\xff\xfe"]
+		sequence2 = ["\x00"]
+		self.handler._onReceive(_speakFrame(sequence1) + _speakFrame(sequence2))
+		self.assertEqual(self.handler.speak_sequences[0], sequence1)
+		self.assertEqual(self.handler.speak_sequences[1], sequence2)
 
 
 # ---------------------------------------------------------------------------
@@ -161,32 +163,27 @@ class TestCoalescedPartial(unittest.TestCase):
 		self.addCleanup(self.handler.terminate)
 
 	def test_complete_plus_partial_then_remainder(self):
-		payload1 = b"complete"
-		payload2 = b"partial-message-payload"
-		msg1 = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload1)
-		msg2 = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, payload2)
+		sequence1 = ["complete"]
+		sequence2 = ["partial-message-payload"]
+		msg1 = _speakFrame(sequence1)
+		msg2 = _speakFrame(sequence2)
 		# Split msg2 after its header, in the middle of its payload.
-		split_in_msg2 = 4 + len(payload2) // 2
-		first_chunk = msg1 + msg2[:split_in_msg2]
-		second_chunk = msg2[split_in_msg2:]
-		self.handler._onReceive(first_chunk)
+		split_in_msg2 = 4 + (len(msg2) - 4) // 2
+		self.handler._onReceive(msg1 + msg2[:split_in_msg2])
 		# message1 must have been dispatched; message2 not yet.
-		self.assertEqual(self.handler.speak_payloads, [payload1])
-		self.handler._onReceive(second_chunk)
-		self.assertEqual(self.handler.speak_payloads, [payload1, payload2])
+		self.assertEqual(self.handler.speak_sequences, [sequence1])
+		self.handler._onReceive(msg2[split_in_msg2:])
+		self.assertEqual(self.handler.speak_sequences, [sequence1, sequence2])
 
 	def test_two_complete_then_partial_then_rest(self):
 		"""Two complete messages, then a partial, then the rest of the partial."""
-		payloads = [b"one", b"two", b"three-is-the-long-one"]
-		msgs = [buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, p) for p in payloads]
-		# First call: msgs[0] + msgs[1] + first half of msgs[2]
-		split = 4 + len(payloads[2]) // 2
-		first_chunk = msgs[0] + msgs[1] + msgs[2][:split]
-		second_chunk = msgs[2][split:]
-		self.handler._onReceive(first_chunk)
-		self.assertEqual(self.handler.speak_payloads, [payloads[0], payloads[1]])
-		self.handler._onReceive(second_chunk)
-		self.assertEqual(self.handler.speak_payloads, payloads)
+		sequences = [["one"], ["two"], ["three-is-the-long-one"]]
+		msgs = [_speakFrame(s) for s in sequences]
+		split = 4 + (len(msgs[2]) - 4) // 2
+		self.handler._onReceive(msgs[0] + msgs[1] + msgs[2][:split])
+		self.assertEqual(self.handler.speak_sequences, [sequences[0], sequences[1]])
+		self.handler._onReceive(msgs[2][split:])
+		self.assertEqual(self.handler.speak_sequences, sequences)
 
 
 # ---------------------------------------------------------------------------
@@ -209,11 +206,11 @@ class TestWrongDriverType(unittest.TestCase):
 		msg = buildMessage(protocol.DriverType.BRAILLE, protocol.SpeechCommand.SPEAK, b"data")
 		with contextlib.suppress(RuntimeError):
 			self.handler._onReceive(msg)
-		self.assertEqual(self.handler.speak_payloads, [])
+		self.assertEqual(self.handler.speak_sequences, [])
 
 
 # ---------------------------------------------------------------------------
-# 6. Empty payload message dispatches with b"".
+# 6. Empty payload message dispatches (CANCEL has an empty payload on the wire).
 # ---------------------------------------------------------------------------
 
 
@@ -223,21 +220,17 @@ class TestEmptyPayload(unittest.TestCase):
 		self.addCleanup(self.handler.terminate)
 
 	def test_empty_payload_dispatches(self):
-		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, b"")
+		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.CANCEL, b"")
 		self.handler._onReceive(msg)
-		self.assertEqual(len(self.handler.speak_payloads), 1)
-
-	def test_empty_payload_value_is_empty_bytes(self):
-		msg = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, b"")
-		self.handler._onReceive(msg)
-		self.assertEqual(self.handler.speak_payloads[0], b"")
+		self.assertEqual(self.handler.cancel_calls, 1)
 
 	def test_empty_payload_then_nonempty(self):
 		"""Empty-payload message followed by a message with payload — both dispatched."""
-		msg1 = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, b"")
-		msg2 = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.SPEAK, b"after")
+		msg1 = buildMessage(protocol.DriverType.SPEECH, protocol.SpeechCommand.CANCEL, b"")
+		msg2 = _speakFrame(["after"])
 		self.handler._onReceive(msg1 + msg2)
-		self.assertEqual(self.handler.speak_payloads, [b"", b"after"])
+		self.assertEqual(self.handler.cancel_calls, 1)
+		self.assertEqual(self.handler.speak_sequences, [["after"]])
 
 
 if __name__ == "__main__":

--- a/tests/test_legacyCodecs.py
+++ b/tests/test_legacyCodecs.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 import pickle
 import sys
 import unittest
+from unittest import mock
 
 import speech.commands
+from autoSettingsUtils.driverSetting import DriverSetting
 from lib.protocol import legacy
 from lib.protocol.braille import BrailleCommand, BrailleInputGesture
 from lib.protocol.messages import RdMessageType
@@ -35,6 +37,33 @@ class FrameTests(unittest.TestCase):
 			legacy.packFrame(legacy.DriverType.SPEECH, SpeechCommand.SPEAK, payload),
 			buildMessage(legacy.DriverType.SPEECH, SpeechCommand.SPEAK, payload),
 		)
+
+
+class PickleHelperTests(unittest.TestCase):
+	"""Tests for legacy.dumps and legacy.loads."""
+
+	def test_roundtrip_plain_structure(self):
+		original = {"key": b"bytes_value", "name": "hello", "count": 42}
+		self.assertEqual(legacy.loads(legacy.dumps(original)), original)
+
+	def test_loads_calls_invalidate_cache_on_auto_property_object(self):
+		"""loads calls invalidateCache on AutoPropertyObject results.
+
+		DriverSetting is used as the probe (rather than an ad hoc AutoPropertyObject subclass)
+		because RestrictedUnpickler only resolves allowlisted classes; see
+		tests/test_restrictedUnpickling.py for the allowlist itself.
+		"""
+		raw = legacy.dumps(DriverSetting("id1", "Setting 1"))
+		with mock.patch.object(DriverSetting, "invalidateCache") as invalidateCache:
+			result = legacy.loads(raw)
+		self.assertIsInstance(result, DriverSetting)
+		invalidateCache.assert_called_once_with()
+
+	def test_loads_does_not_call_invalidate_cache_on_plain_objects(self):
+		"""loads does not call invalidateCache on non-AutoPropertyObject results."""
+		# dict has no invalidateCache; if loads tried to call it this would raise.
+		data = {"x": 1}
+		self.assertEqual(legacy.loads(legacy.dumps(data)), data)
 
 
 class SpeechCommandCodecTests(unittest.TestCase):

--- a/tests/test_legacyCodecs.py
+++ b/tests/test_legacyCodecs.py
@@ -1,0 +1,209 @@
+# RDAccess: Remote Desktop Accessibility for NVDA
+# Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
+# License: GNU General Public License version 2.0
+
+"""Tests for the legacy (protocol v1) byte codecs in ``lib.protocol.legacy``.
+
+Encoded output is compared against golden bytes matching what protocol v1 peers
+put on the wire, so the legacy path stays wire-compatible while the rest of the
+handler moves to value-based messages.
+"""
+
+from __future__ import annotations
+
+import pickle
+import sys
+import unittest
+
+import speech.commands
+from lib.protocol import legacy
+from lib.protocol.braille import BrailleCommand, BrailleInputGesture
+from lib.protocol.messages import RdMessageType
+from lib.protocol.speech import SpeechCommand
+
+from ._fakes import buildMessage
+
+
+def _goldenPickle(obj) -> bytes:
+	return pickle.dumps(obj, protocol=4)
+
+
+class FrameTests(unittest.TestCase):
+	def test_packFrameMatchesWireFormat(self):
+		payload = b"payload bytes"
+		self.assertEqual(
+			legacy.packFrame(legacy.DriverType.SPEECH, SpeechCommand.SPEAK, payload),
+			buildMessage(legacy.DriverType.SPEECH, SpeechCommand.SPEAK, payload),
+		)
+
+
+class SpeechCommandCodecTests(unittest.TestCase):
+	def test_speak(self):
+		sequence = ["Hello", speech.commands.IndexCommand(5)]
+		command, payload = legacy.encodeCommandPayload(
+			legacy.DriverType.SPEECH,
+			RdMessageType.SPEAK,
+			{"sequence": sequence},
+		)
+		self.assertEqual(command, SpeechCommand.SPEAK)
+		self.assertEqual(payload, _goldenPickle(sequence))
+		msgType, kwargs = legacy.decodeCommandPayload(legacy.DriverType.SPEECH, command, payload)
+		self.assertEqual(msgType, RdMessageType.SPEAK)
+		self.assertEqual(kwargs, {"sequence": sequence})
+
+	def test_cancel(self):
+		command, payload = legacy.encodeCommandPayload(legacy.DriverType.SPEECH, RdMessageType.CANCEL, {})
+		self.assertEqual(command, SpeechCommand.CANCEL)
+		self.assertEqual(payload, b"")
+		self.assertEqual(
+			legacy.decodeCommandPayload(legacy.DriverType.SPEECH, command, payload),
+			(RdMessageType.CANCEL, {}),
+		)
+
+	def test_pause(self):
+		for switch, expected in ((True, b"\x01"), (False, b"\x00")):
+			with self.subTest(switch=switch):
+				command, payload = legacy.encodeCommandPayload(
+					legacy.DriverType.SPEECH,
+					RdMessageType.PAUSE_SPEECH,
+					{"switch": switch},
+				)
+				self.assertEqual(command, SpeechCommand.PAUSE)
+				self.assertEqual(payload, expected)
+				self.assertEqual(
+					legacy.decodeCommandPayload(legacy.DriverType.SPEECH, command, payload),
+					(RdMessageType.PAUSE_SPEECH, {"switch": switch}),
+				)
+
+	def test_index(self):
+		command, payload = legacy.encodeCommandPayload(
+			legacy.DriverType.SPEECH,
+			RdMessageType.INDEX,
+			{"index": 42},
+		)
+		self.assertEqual(command, SpeechCommand.INDEX_REACHED)
+		self.assertEqual(payload, (42).to_bytes(2, sys.byteorder, signed=False))
+		self.assertEqual(
+			legacy.decodeCommandPayload(legacy.DriverType.SPEECH, command, payload),
+			(RdMessageType.INDEX, {"index": 42}),
+		)
+
+	def test_toneAndWave(self):
+		for msgType, command, kwargs in (
+			(RdMessageType.TONE, SpeechCommand.BEEP, {"hz": 440.0, "length": 100, "left": 50, "right": 50}),
+			(RdMessageType.WAVE, SpeechCommand.PLAY_WAVE_FILE, {"fileName": "waves/exit.wav"}),
+		):
+			with self.subTest(type=msgType):
+				encodedCommand, payload = legacy.encodeCommandPayload(
+					legacy.DriverType.SPEECH,
+					msgType,
+					dict(kwargs),
+				)
+				self.assertEqual(encodedCommand, command)
+				self.assertEqual(payload, _goldenPickle(kwargs))
+				self.assertEqual(
+					legacy.decodeCommandPayload(legacy.DriverType.SPEECH, command, payload),
+					(msgType, kwargs),
+				)
+
+
+class BrailleCommandCodecTests(unittest.TestCase):
+	def test_display(self):
+		cells = [0, 1, 128, 255]
+		command, payload = legacy.encodeCommandPayload(
+			legacy.DriverType.BRAILLE,
+			RdMessageType.DISPLAY,
+			{"cells": cells},
+		)
+		self.assertEqual(command, BrailleCommand.DISPLAY)
+		self.assertEqual(payload, bytes(cells))
+		self.assertEqual(
+			legacy.decodeCommandPayload(legacy.DriverType.BRAILLE, command, payload),
+			(RdMessageType.DISPLAY, {"cells": cells}),
+		)
+
+	def test_brailleInput(self):
+		kwargs = {
+			"source": "remote",
+			"id": "dot1",
+			"routingIndex": None,
+			"model": None,
+			"dots": 1,
+			"space": False,
+		}
+		command, payload = legacy.encodeCommandPayload(
+			legacy.DriverType.BRAILLE,
+			RdMessageType.BRAILLE_INPUT,
+			dict(kwargs),
+		)
+		self.assertEqual(command, BrailleCommand.EXECUTE_GESTURE)
+		gesture = legacy.restrictedLoads(payload)
+		self.assertIsInstance(gesture, BrailleInputGesture)
+		msgType, decoded = legacy.decodeCommandPayload(legacy.DriverType.BRAILLE, command, payload)
+		self.assertEqual(msgType, RdMessageType.BRAILLE_INPUT)
+		self.assertEqual(decoded, kwargs)
+
+	def test_wrongDriverTypeRejected(self):
+		with self.assertRaises(ValueError):
+			legacy.encodeCommandPayload(legacy.DriverType.SPEECH, RdMessageType.DISPLAY, {"cells": []})
+		with self.assertRaises(ValueError):
+			legacy.decodeCommandPayload(legacy.DriverType.BRAILLE, SpeechCommand.SPEAK, b"")
+
+
+class AttributeMessageCodecTests(unittest.TestCase):
+	def test_request(self):
+		command, payload = legacy.encodeCommandPayload(
+			legacy.DriverType.SPEECH,
+			RdMessageType.ATTRIBUTE_REQUEST,
+			{"attribute": "language"},
+		)
+		self.assertEqual(command, legacy.GenericCommand.ATTRIBUTE)
+		self.assertEqual(payload, b"`language`")
+		self.assertEqual(
+			legacy.decodeCommandPayload(legacy.DriverType.SPEECH, command, payload),
+			(RdMessageType.ATTRIBUTE_REQUEST, {"attribute": "language"}),
+		)
+
+	def test_value(self):
+		command, payload = legacy.encodeCommandPayload(
+			legacy.DriverType.SPEECH,
+			RdMessageType.ATTRIBUTE_VALUE,
+			{"attribute": "language", "value": "nl"},
+		)
+		self.assertEqual(command, legacy.GenericCommand.ATTRIBUTE)
+		self.assertEqual(payload, b"`language`" + _goldenPickle("nl"))
+		self.assertEqual(
+			legacy.decodeCommandPayload(legacy.DriverType.SPEECH, command, payload),
+			(RdMessageType.ATTRIBUTE_VALUE, {"attribute": "language", "value": "nl"}),
+		)
+
+
+class AttributeValueCodecTests(unittest.TestCase):
+	def roundTrip(self, attribute: str, value, expectedBytes: bytes):
+		encoded = legacy.encodeAttributeValue(attribute, value)
+		self.assertEqual(encoded, expectedBytes)
+		self.assertEqual(legacy.decodeAttributeValue(attribute, encoded), value)
+
+	def test_versionStrings(self):
+		self.roundTrip("nvdaVersion", "2026.1.0", b"2026.1.0")
+		self.roundTrip("rdAccessVersion", "1.7.2", b"1.7.2")
+
+	def test_protocolVersion(self):
+		self.roundTrip("protocolVersion", 2, b"\x02")
+
+	def test_timeSinceInput(self):
+		self.roundTrip("timeSinceInput", 1234, (1234).to_bytes(4, sys.byteorder, signed=False))
+
+	def test_cellCounts(self):
+		self.roundTrip("numCells", 40, b"\x28")
+		self.roundTrip("numCols", 20, b"\x14")
+		self.roundTrip("numRows", 1, b"\x01")
+
+	def test_pickledFallback(self):
+		for attribute, value in (
+			("language", "nl"),
+			("setting_rate", 50),
+			("supportedSettings", []),
+		):
+			with self.subTest(attribute=attribute):
+				self.roundTrip(attribute, value, _goldenPickle(value))

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -28,15 +28,15 @@ class _HandlerWithLanguageReceiver(FakeHandlerBase):
 
 
 class _HandlerWithRecordingCommandHandler(FakeHandlerBase):
-	"""Adds a SPEAK commandHandler that records the payload it receives."""
+	"""Adds a SPEAK commandHandler that records the sequence it receives."""
 
 	def __init__(self):
 		super().__init__()
-		self.receivedPayloads: list[bytes] = []
+		self.receivedSequences: list[list] = []
 
-	@protocol.commandHandler(protocol.SpeechCommand.SPEAK)
-	def _handle_speak(self, payload: bytes):
-		self.receivedPayloads.append(payload)
+	@protocol.commandHandler(protocol.RdMessageType.SPEAK)
+	def _handle_speak(self, sequence: list):
+		self.receivedSequences.append(sequence)
 
 
 # ---------------------------------------------------------------------------
@@ -93,24 +93,24 @@ class TestLargePayloadRoundtrip(unittest.TestCase):
 		self.addCleanup(self.receiver.terminate)
 
 	def test_large_payload_length_field(self):
-		"""300-byte payload encodes its length correctly in the 2-byte field."""
-		payload = bytes(range(256)) + bytes(range(44))  # 300 bytes
-		self.sender.writeMessage(protocol.SpeechCommand.SPEAK, payload)
+		"""A payload larger than 255 bytes exercises both bytes of the length field."""
+		sequence = ["x" * 300]
+		self.sender.sendMessage(protocol.RdMessageType.SPEAK, sequence=sequence)
 
 		written = self.sender._dev.writes[0]
 		length_field = int.from_bytes(written[2:4], sys.byteorder)
-		self.assertEqual(length_field, 300)
+		self.assertEqual(length_field, len(written) - 4)
+		self.assertGreater(length_field, 255)
 
 	def test_large_payload_roundtrip_via_on_receive(self):
-		"""Feeding large written bytes into _onReceive dispatches the payload intact."""
-		payload = bytes(range(256)) + bytes(range(44))  # 300 bytes
-		self.sender.writeMessage(protocol.SpeechCommand.SPEAK, payload)
+		"""Feeding large written bytes into _onReceive dispatches the sequence intact."""
+		sequence = ["x" * 300]
+		self.sender.sendMessage(protocol.RdMessageType.SPEAK, sequence=sequence)
 
 		wire_bytes = self.sender._dev.writes[0]
 		self.receiver._onReceive(wire_bytes)
 
-		self.assertEqual(len(self.receiver.receivedPayloads), 1)
-		self.assertEqual(self.receiver.receivedPayloads[0], payload)
+		self.assertEqual(self.receiver.receivedSequences, [sequence])
 
 
 class TestSetRemoteAttribute(unittest.TestCase):

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -23,8 +23,8 @@ class _HandlerWithLanguageReceiver(FakeHandlerBase):
 	"""Adds a LANGUAGE attributeReceiver so attribute receipt can be tested."""
 
 	@protocol.attributeReceiver(protocol.SpeechAttribute.LANGUAGE, defaultValue="en")
-	def _incoming_language(self, payload: bytes) -> str:
-		return payload.decode()
+	def _incoming_language(self, value: str) -> str:
+		return value
 
 
 class _HandlerWithRecordingCommandHandler(FakeHandlerBase):
@@ -122,7 +122,7 @@ class TestSetRemoteAttribute(unittest.TestCase):
 
 	def test_set_remote_attribute_payload_format(self):
 		"""setRemoteAttribute writes ATTRIBUTE command with `attribute`value payload."""
-		self.handler.setRemoteAttribute(b"language", b"nl")
+		self.handler.setRemoteAttribute("language", "nl")
 
 		self.assertEqual(len(self.handler._dev.writes), 1)
 		written = self.handler._dev.writes[0]
@@ -134,7 +134,7 @@ class TestSetRemoteAttribute(unittest.TestCase):
 
 		# payload is everything after the 4-byte header
 		payload = written[4:]
-		expected_payload = b"`language`nl"
+		expected_payload = b"`language`" + protocol.legacy.encodeAttributeValue("language", "nl")
 		self.assertEqual(payload, expected_payload)
 
 
@@ -147,7 +147,7 @@ class TestRequestRemoteAttribute(unittest.TestCase):
 
 	def test_request_remote_attribute_payload_format(self):
 		"""requestRemoteAttribute writes ATTRIBUTE command with trailing separator and empty value."""
-		self.handler.requestRemoteAttribute(b"language")
+		self.handler.requestRemoteAttribute("language")
 
 		self.assertEqual(len(self.handler._dev.writes), 1)
 		written = self.handler._dev.writes[0]
@@ -162,18 +162,18 @@ class TestRequestRemoteAttribute(unittest.TestCase):
 
 	def test_request_remote_attribute_sets_pending(self):
 		"""requestRemoteAttribute marks the attribute request as pending."""
-		self.handler.requestRemoteAttribute(b"language")
+		self.handler.requestRemoteAttribute("language")
 
 		self.assertTrue(
-			self.handler._attributeValueProcessor.isAttributeRequestPending(b"language"),
+			self.handler._attributeValueProcessor.isAttributeRequestPending("language"),
 		)
 
 	def test_duplicate_request_suppressed(self):
 		"""Second requestRemoteAttribute for the same pending attribute does not write again."""
-		self.handler.requestRemoteAttribute(b"language")
+		self.handler.requestRemoteAttribute("language")
 		writes_after_first = len(self.handler._dev.writes)
 
-		self.handler.requestRemoteAttribute(b"language")
+		self.handler.requestRemoteAttribute("language")
 		writes_after_second = len(self.handler._dev.writes)
 
 		self.assertEqual(writes_after_first, writes_after_second)
@@ -192,7 +192,7 @@ class TestPendingClearedOnReceipt(unittest.TestCase):
 		self.handler.requestRemoteAttribute(attr)
 		self.assertTrue(self.handler._attributeValueProcessor.isAttributeRequestPending(attr))
 
-		self.handler._attributeValueProcessor(attr, b"nl")
+		self.handler._attributeValueProcessor(attr, "nl")
 
 		self.assertFalse(self.handler._attributeValueProcessor.isAttributeRequestPending(attr))
 
@@ -201,7 +201,7 @@ class TestPendingClearedOnReceipt(unittest.TestCase):
 		attr = protocol.SpeechAttribute.LANGUAGE
 		self.handler.requestRemoteAttribute(attr)
 
-		self.handler._attributeValueProcessor(attr, b"nl")
+		self.handler._attributeValueProcessor(attr, "nl")
 
 		value = self.handler._attributeValueProcessor.getValue(attr, fallBackToDefault=False)
 		self.assertEqual(value, "nl")
@@ -210,7 +210,7 @@ class TestPendingClearedOnReceipt(unittest.TestCase):
 		"""Attribute receipt without a prior request still stores the value and leaves pending=False."""
 		attr = protocol.SpeechAttribute.LANGUAGE
 		# No requestRemoteAttribute call — just a push from the remote side
-		self.handler._attributeValueProcessor(attr, b"en-GB")
+		self.handler._attributeValueProcessor(attr, "en-GB")
 
 		self.assertFalse(self.handler._attributeValueProcessor.isAttributeRequestPending(attr))
 		value = self.handler._attributeValueProcessor.getValue(attr, fallBackToDefault=False)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -44,36 +44,39 @@ class _HandlerWithRecordingCommandHandler(FakeHandlerBase):
 # ---------------------------------------------------------------------------
 
 
-class TestWriteMessage(unittest.TestCase):
-	"""Test 1 & 2: basic writeMessage behaviour."""
+class TestLegacySendWireFormat(unittest.TestCase):
+	"""Tests 1 & 2: legacy wire bytes produced by sendMessage before the JSON switch."""
 
 	def setUp(self):
 		self.handler = FakeHandlerBase()
 		self.addCleanup(self.handler.terminate)
 
-	def test_write_message_speak_with_payload(self):
-		"""writeMessage produces the correct wire bytes for a non-empty payload."""
-		payload = b"abc"
-		self.handler.writeMessage(protocol.SpeechCommand.SPEAK, payload)
+	def test_send_message_speak_frame_layout(self):
+		"""A SPEAK message writes driverType, command byte, LE length field and payload."""
+		self.handler.sendMessage(protocol.RdMessageType.SPEAK, sequence=["abc"])
 
-		expected = b"S" + bytes([protocol.SpeechCommand.SPEAK]) + (3).to_bytes(2, sys.byteorder) + b"abc"
+		written = self.handler._dev.writes[0]
+		self.assertEqual(written[0:1], b"S")
+		self.assertEqual(written[1], protocol.SpeechCommand.SPEAK)
+		length_field = int.from_bytes(written[2:4], sys.byteorder)
+		self.assertEqual(length_field, len(written) - 4)
+
+	def test_send_message_matches_build_message(self):
+		"""sendMessage output is identical to the buildMessage helper over the encoded payload."""
+		sequence = ["abc"]
+		self.handler.sendMessage(protocol.RdMessageType.SPEAK, sequence=sequence)
+
+		command, payload = protocol.legacy.encodeCommandPayload(
+			protocol.DriverType.SPEECH,
+			protocol.RdMessageType.SPEAK,
+			{"sequence": sequence},
+		)
+		expected = buildMessage(protocol.DriverType.SPEECH, command, payload)
 		self.assertEqual(self.handler._dev.writes, [expected])
 
-	def test_write_message_matches_build_message(self):
-		"""writeMessage output is identical to buildMessage helper."""
-		payload = b"abc"
-		self.handler.writeMessage(protocol.SpeechCommand.SPEAK, payload)
-
-		expected = buildMessage(
-			protocol.DriverType.SPEECH,
-			protocol.SpeechCommand.SPEAK,
-			payload,
-		)
-		self.assertEqual(self.handler._dev.writes[0], expected)
-
-	def test_write_message_default_empty_payload(self):
-		"""writeMessage with no payload argument writes a zero-length field and no payload bytes."""
-		self.handler.writeMessage(protocol.SpeechCommand.CANCEL)
+	def test_send_message_empty_payload(self):
+		"""CANCEL writes a zero-length field and no payload bytes."""
+		self.handler.sendMessage(protocol.RdMessageType.CANCEL)
 
 		written = self.handler._dev.writes[0]
 		# Length field is bytes 2-3; must be zero

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3,7 +3,7 @@
 # License: GNU General Public License version 2.0
 
 """Unit tests for utility behaviour of RemoteProtocolHandler:
-_safeWait, _pickle, _unpickle, terminate, _queueFunctionOnMainThread.
+_safeWait, terminate, _queueFunctionOnMainThread.
 """
 
 from __future__ import annotations
@@ -11,10 +11,8 @@ from __future__ import annotations
 import gc
 import unittest
 import weakref
-from unittest import mock
 
 import queueHandler  # noqa: E402 — must follow tests import so stubs are installed
-from autoSettingsUtils.driverSetting import DriverSetting  # noqa: E402 — same reason
 
 from tests._fakes import FakeHandlerBase  # bootstrap runs via tests/__init__ import
 
@@ -58,43 +56,6 @@ class TestSafeWait(unittest.TestCase):
 		result = self.handler._safeWait(_predicate, timeout=1.0)
 		self.assertTrue(result)
 		self.assertGreaterEqual(len(calls), 2)
-
-
-class TestPickleUnpickle(unittest.TestCase):
-	"""Tests for RemoteProtocolHandler._pickle and _unpickle."""
-
-	def setUp(self):
-		self.handler = FakeHandlerBase()
-		self.addCleanup(self.handler.terminate)
-
-	def test_roundtrip_plain_structure(self):
-		"""_unpickle(_pickle(obj)) reproduces the original plain structure."""
-		original = {"key": b"bytes_value", "name": "hello", "count": 42}
-		raw = self.handler._pickle(original)
-		restored = self.handler._unpickle(raw)
-		self.assertEqual(restored, original)
-
-	def test_unpickle_calls_invalidate_cache_on_auto_property_object(self):
-		"""_unpickle calls invalidateCache on AutoPropertyObject results.
-
-		DriverSetting is used as the probe (rather than an ad hoc AutoPropertyObject subclass)
-		because RestrictedUnpickler only resolves allowlisted classes; see
-		tests/test_restrictedUnpickling.py for the allowlist itself.
-		"""
-		original = DriverSetting("id1", "Setting 1")
-		raw = self.handler._pickle(original)
-		with mock.patch.object(DriverSetting, "invalidateCache") as invalidateCache:
-			result = self.handler._unpickle(raw)
-		self.assertIsInstance(result, DriverSetting)
-		invalidateCache.assert_called_once_with()
-
-	def test_unpickle_does_not_call_invalidate_cache_on_plain_objects(self):
-		"""_unpickle does not call invalidateCache on non-AutoPropertyObject results."""
-		# dict has no invalidateCache; if _unpickle tried to call it this would raise.
-		data = {"x": 1}
-		raw = self.handler._pickle(data)
-		result = self.handler._unpickle(raw)
-		self.assertEqual(result, data)
 
 
 class TestTerminate(unittest.TestCase):

--- a/tests/test_restrictedUnpickling.py
+++ b/tests/test_restrictedUnpickling.py
@@ -3,7 +3,7 @@
 # License: GNU General Public License version 2.0
 
 """Unit tests for RestrictedUnpickler, the pickle.Unpickler subclass in
-addon/lib/protocol/_restrictedUnpickling.py used by RemoteProtocolHandler._unpickle to allowlist
+addon/lib/protocol/_restrictedUnpickling.py used by lib.protocol.legacy to allowlist
 the classes that legitimately cross the RDAccess wire, blocking generic __reduce__-based RCE gadgets.
 """
 
@@ -18,12 +18,11 @@ from typing import Any
 from autoSettingsUtils.driverSetting import BooleanDriverSetting, DriverSetting, NumericDriverSetting
 from autoSettingsUtils.utils import StringParameterInfo
 from inputCore import GlobalGestureMap
+from lib.protocol import legacy
 from lib.protocol.braille import BrailleInputGesture
 from logHandler import log
 from speech.commands import IndexCommand, NotASpeechCommand, PitchCommand
 from synthDriverHandler import VoiceInfo
-
-from tests._fakes import FakeHandlerBase
 
 # ---------------------------------------------------------------------------
 # Helper: mimics a __reduce__-based RCE gadget, the classic pickle attack shape.
@@ -52,21 +51,17 @@ class _ReduceGadget:
 
 
 class TestRestrictedUnpicklingRejections(unittest.TestCase):
-	def setUp(self):
-		self.handler = FakeHandlerBase()
-		self.addCleanup(self.handler.terminate)
-
 	def test_rejects_os_system_reduce_gadget(self):
 		"""A payload whose __reduce__ references os.system must not be unpickled."""
 		payload = pickle.dumps(_ReduceGadget(os.system, ("echo pwned",)), protocol=4)
 		with self.assertRaises(pickle.UnpicklingError):
-			self.handler._unpickle(payload)
+			legacy.loads(payload)
 
 	def test_rejects_builtins_eval_reduce_gadget(self):
 		"""A payload whose __reduce__ references builtins.eval must not be unpickled."""
 		payload = pickle.dumps(_ReduceGadget(eval, ("1+1",)), protocol=4)
 		with self.assertRaises(pickle.UnpicklingError):
-			self.handler._unpickle(payload)
+			legacy.loads(payload)
 
 	def test_rejects_non_speechcommand_name_in_speech_commands_module(self):
 		"""The dynamic speech.commands rule must refuse names that exist in the module but are not
@@ -74,13 +69,13 @@ class TestRestrictedUnpicklingRejections(unittest.TestCase):
 		"""
 		payload = pickle.dumps(NotASpeechCommand, protocol=4)
 		with self.assertRaises(pickle.UnpicklingError):
-			self.handler._unpickle(payload)
+			legacy.loads(payload)
 
 	def test_rejects_arbitrary_unknown_class(self):
 		"""A class that never crosses the wire legitimately (and isn't in the allowlist) is refused."""
 		payload = pickle.dumps(collections.Counter, protocol=4)
 		with self.assertRaises(pickle.UnpicklingError):
-			self.handler._unpickle(payload)
+			legacy.loads(payload)
 
 	def test_rejection_is_logged_as_error(self):
 		"""Rejections are logged via log.error, since exceptions raised inside _bgExecutor futures
@@ -89,7 +84,7 @@ class TestRestrictedUnpicklingRejections(unittest.TestCase):
 		log.records.clear()
 		payload = pickle.dumps(_ReduceGadget(os.system, ("echo pwned",)), protocol=4)
 		with self.assertRaises(pickle.UnpicklingError):
-			self.handler._unpickle(payload)
+			legacy.loads(payload)
 		errorRecords = [msg for level, msg in log.records if level == "error"]
 		self.assertTrue(errorRecords, "Expected a log.error call recording the rejected global")
 		# os.system's actual module is platform-specific (nt on Windows, posixpath on Unix)
@@ -101,18 +96,14 @@ class TestRestrictedUnpicklingRejections(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# Acceptance cases: round-trip _pickle -> _unpickle for everything that legitimately
+# Acceptance cases: round-trip legacy.dumps -> legacy.loads for everything that legitimately
 # crosses the wire (see the audit table in the implementation plan).
 # ---------------------------------------------------------------------------
 
 
 class TestRestrictedUnpicklingAcceptance(unittest.TestCase):
-	def setUp(self):
-		self.handler = FakeHandlerBase()
-		self.addCleanup(self.handler.terminate)
-
 	def _roundtrip(self, obj: Any) -> Any:
-		return self.handler._unpickle(self.handler._pickle(obj))
+		return legacy.loads(legacy.dumps(obj))
 
 	def test_roundtrips_speech_sequence(self):
 		original = ["hello", IndexCommand(1), PitchCommand(offset=5)]

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,0 +1,187 @@
+# RDAccess: Remote Desktop Accessibility for NVDA
+# Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
+# License: GNU General Public License version 2.0
+
+"""Tests for the protocol v2 JSON serializer (``lib.protocol.serializer``)."""
+
+from __future__ import annotations
+
+import unittest
+from collections import OrderedDict
+
+import inputCore
+import speech.commands
+from autoSettingsUtils.driverSetting import BooleanDriverSetting, DriverSetting, NumericDriverSetting
+from autoSettingsUtils.utils import StringParameterInfo
+from lib.protocol.messages import RdMessageType
+from lib.protocol.serializer import RdJSONSerializer
+from logHandler import log
+from synthDriverHandler import VoiceInfo
+
+
+class SerializerTestCase(unittest.TestCase):
+	def setUp(self):
+		self.serializer = RdJSONSerializer()
+		log.records.clear()
+
+	def roundTrip(self, msgType: RdMessageType, **payload) -> dict:
+		data = self.serializer.serialize(type=msgType, **payload)
+		self.assertTrue(data.endswith(b"\n"))
+		self.assertEqual(data[0:1], b"{")
+		return self.serializer.deserialize(data)
+
+	def roundTripAttribute(self, attribute: str, value):
+		obj = self.roundTrip(RdMessageType.ATTRIBUTE_VALUE, attribute=attribute, value=value)
+		self.assertEqual(obj["attribute"], attribute)
+		return obj["value"]
+
+
+class SpeakSequenceTests(SerializerTestCase):
+	def test_roundTrip(self):
+		sequence = [
+			"Hello ",
+			speech.commands.IndexCommand(5),
+			"world",
+			speech.commands.PitchCommand(offset=30),
+			speech.commands.EndUtteranceCommand(),
+		]
+		obj = self.roundTrip(RdMessageType.SPEAK, sequence=sequence)
+		self.assertEqual(obj["sequence"], sequence)
+
+	def test_unknownClassSkipped(self):
+		data = b'{"sequence": ["hi", ["NoSuchCommand", {}]], "type": "speak"}\n'
+		obj = self.serializer.deserialize(data)
+		self.assertEqual(obj["sequence"], ["hi"])
+		self.assertTrue(any("NoSuchCommand" in msg for _level, msg in log.records))
+
+	def test_nonSequenceClassSkipped(self):
+		"""A class in speech.commands outside SEQUENCE_CLASSES must not be instantiated."""
+		data = b'{"sequence": [["NotASpeechCommand", {}]], "type": "speak"}\n'
+		obj = self.serializer.deserialize(data)
+		self.assertEqual(obj["sequence"], [])
+
+
+class SupportedSettingsTests(SerializerTestCase):
+	def _settings(self) -> list[DriverSetting]:
+		return [
+			DriverSetting("voice", "&Voice", availableInSettingsRing=True),
+			NumericDriverSetting("rate", "&Rate", defaultVal=50),
+			BooleanDriverSetting("rateBoost", "Rate boos&t", defaultVal=False),
+		]
+
+	def test_roundTrip(self):
+		settings = self._settings()
+		decoded = self.roundTripAttribute("supportedSettings", settings)
+		self.assertEqual(len(decoded), 3)
+		for original, new in zip(settings, decoded, strict=True):
+			self.assertIs(type(new), type(original))
+			expected = {k: v for k, v in original.__dict__.items() if k != "_propertyCache"}
+			actual = {k: v for k, v in new.__dict__.items() if k != "_propertyCache"}
+			self.assertEqual(actual, expected)
+
+	def test_propertyCacheExcludedAndFresh(self):
+		setting = DriverSetting("voice", "&Voice")
+		setting._propertyCache[SupportedSettingsTests.test_roundTrip] = "poison"
+		(decoded,) = self.roundTripAttribute("supportedSettings", [setting])
+		self.assertEqual(len(decoded._propertyCache), 0)
+
+	def test_unknownClassRejected(self):
+		data = self.serializer.serialize(
+			type=RdMessageType.ATTRIBUTE_VALUE,
+			attribute="supportedSettings",
+			value=[["Evil", {"id": "x"}]],
+		)
+		with self.assertRaises(ValueError):
+			self.serializer.deserialize(data)
+
+
+class AvailableValuesTests(SerializerTestCase):
+	def test_roundTripPreservesOrderAndTypes(self):
+		voices = OrderedDict((
+			("zoe", VoiceInfo("zoe", "Zoe", language="en_US")),
+			("anna", VoiceInfo("anna", "Anna", language="nl_NL")),
+			("plain", StringParameterInfo("plain", "Plain")),
+		))
+		decoded = self.roundTripAttribute("availableVoices", voices)
+		self.assertIsInstance(decoded, OrderedDict)
+		self.assertEqual(list(decoded.keys()), list(voices.keys()))
+		for key, original in voices.items():
+			new = decoded[key]
+			self.assertIs(type(new), type(original))
+			self.assertEqual(new, original)
+
+	def test_unknownClassRejected(self):
+		data = self.serializer.serialize(
+			type=RdMessageType.ATTRIBUTE_VALUE,
+			attribute="availableVoices",
+			value={"x": ["Evil", {"id": "x"}]},
+		)
+		with self.assertRaises(ValueError):
+			self.serializer.deserialize(data)
+
+
+class SupportedCommandsTests(SerializerTestCase):
+	def test_roundTrip(self):
+		commands = frozenset((
+			speech.commands.IndexCommand,
+			speech.commands.PitchCommand,
+			speech.commands.BreakCommand,
+		))
+		decoded = self.roundTripAttribute("supportedCommands", commands)
+		self.assertEqual(decoded, commands)
+
+	def test_unknownAndNonCommandNamesDropped(self):
+		data = self.serializer.serialize(
+			type=RdMessageType.ATTRIBUTE_VALUE,
+			attribute="supportedCommands",
+			value=["IndexCommand", "NotASpeechCommand", "NoSuchCommand"],
+		)
+		decoded = self.serializer.deserialize(data)["value"]
+		self.assertEqual(decoded, frozenset((speech.commands.IndexCommand,)))
+
+
+class GestureMapTests(SerializerTestCase):
+	def test_roundTrip(self):
+		gestureMap = inputCore.GlobalGestureMap(
+			{"globalCommands.GlobalCommands": {"kb:a": "nextHeading", "kb:b": ["one", "two"]}},
+		)
+		decoded = self.roundTripAttribute("gestureMap", gestureMap)
+		self.assertIsInstance(decoded, inputCore.GlobalGestureMap)
+		self.assertEqual(decoded.export(), gestureMap.export())
+
+	def test_noneRoundTrip(self):
+		self.assertIsNone(self.roundTripAttribute("gestureMap", None))
+
+	def test_wrongClassRejected(self):
+		data = self.serializer.serialize(
+			type=RdMessageType.ATTRIBUTE_VALUE,
+			attribute="gestureMap",
+			value=["Evil", {}],
+		)
+		with self.assertRaises(ValueError):
+			self.serializer.deserialize(data)
+
+
+class ScalarAttributeTests(SerializerTestCase):
+	def test_settingValuesPassThrough(self):
+		for value in ("espeak", 50, 1.5, True, None):
+			with self.subTest(value=value):
+				self.assertEqual(self.roundTripAttribute("setting_rate", value), value)
+
+	def test_genericAttributesPassThrough(self):
+		self.assertEqual(self.roundTripAttribute("protocolVersion", 2), 2)
+		self.assertEqual(self.roundTripAttribute("timeSinceInput", 1234), 1234)
+		self.assertEqual(self.roundTripAttribute("language", None), None)
+
+
+class PlainMessageTests(SerializerTestCase):
+	def test_typeIsStringValue(self):
+		data = self.serializer.serialize(type=RdMessageType.CANCEL)
+		obj = self.serializer.deserialize(data)
+		self.assertEqual(obj["type"], "cancel")
+
+	def test_toneAndDisplay(self):
+		obj = self.roundTrip(RdMessageType.TONE, hz=440.0, length=100, left=50, right=50)
+		self.assertEqual(obj["hz"], 440.0)
+		obj = self.roundTrip(RdMessageType.DISPLAY, cells=[0, 1, 255])
+		self.assertEqual(obj["cells"], [0, 1, 255])

--- a/tests/test_serializerConformance.py
+++ b/tests/test_serializerConformance.py
@@ -1,0 +1,51 @@
+# RDAccess: Remote Desktop Accessibility for NVDA
+# Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
+# License: GNU General Public License version 2.0
+
+"""Conformance tests against NVDA core's Remote Access protocol.
+
+These tests compare RDAccess's protocol v2 with the ``_remoteClient`` modules from the
+sibling NVDA source checkout. They fail as soon as the NVDA Remote wire protocol drifts
+from what RDAccess mirrors.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from lib.protocol.messages import RdMessageType
+
+from ._nvdaRemote import protocol as nvdaRemoteProtocol
+
+
+class MessageTypeConformanceTests(unittest.TestCase):
+	"""Mirrored message type values must stay identical to RemoteMessageType."""
+
+	MIRRORED_MEMBERS = (
+		"PROTOCOL_VERSION",
+		"PING",
+		"SPEAK",
+		"CANCEL",
+		"PAUSE_SPEECH",
+		"TONE",
+		"WAVE",
+		"INDEX",
+		"DISPLAY",
+		"BRAILLE_INPUT",
+	)
+
+	def test_mirroredValuesMatchNvdaRemote(self):
+		for name in self.MIRRORED_MEMBERS:
+			with self.subTest(member=name):
+				self.assertEqual(
+					RdMessageType[name].value,
+					nvdaRemoteProtocol.RemoteMessageType[name].value,
+				)
+
+	def test_rdAccessSpecificMembersAbsentFromNvdaRemote(self):
+		"""RDAccess-specific types must not collide with names NVDA Remote may assign later
+		to different semantics without conformance tests noticing."""
+		rdSpecific = set(RdMessageType.__members__) - set(self.MIRRORED_MEMBERS)
+		for name in rdSpecific:
+			with self.subTest(member=name):
+				self.assertNotIn(name, nvdaRemoteProtocol.RemoteMessageType.__members__)

--- a/tests/test_serializerConformance.py
+++ b/tests/test_serializerConformance.py
@@ -13,9 +13,12 @@ from __future__ import annotations
 
 import unittest
 
+import speech.commands
+from lib.protocol import serializer as rdSerializer
 from lib.protocol.messages import RdMessageType
 
 from ._nvdaRemote import protocol as nvdaRemoteProtocol
+from ._nvdaRemote import serializer as nvdaRemoteSerializer
 
 
 class MessageTypeConformanceTests(unittest.TestCase):
@@ -49,3 +52,56 @@ class MessageTypeConformanceTests(unittest.TestCase):
 		for name in rdSpecific:
 			with self.subTest(member=name):
 				self.assertNotIn(name, nvdaRemoteProtocol.RemoteMessageType.__members__)
+
+
+class SerializerConformanceTests(unittest.TestCase):
+	"""Shared message types must serialize byte-for-byte identically to NVDA Remote."""
+
+	def setUp(self):
+		self.ours = rdSerializer.RdJSONSerializer()
+		self.theirs = nvdaRemoteSerializer.JSONSerializer()
+
+	def test_separator(self):
+		self.assertEqual(rdSerializer.RdJSONSerializer.SEP, nvdaRemoteSerializer.JSONSerializer.SEP)
+
+	def test_sequenceClasses(self):
+		self.assertEqual(rdSerializer.SEQUENCE_CLASSES, nvdaRemoteSerializer.SEQUENCE_CLASSES)
+
+	def _sampleSequence(self) -> list:
+		return [
+			"Hello ",
+			speech.commands.IndexCommand(1),
+			"world",
+			speech.commands.PitchCommand(offset=30),
+			speech.commands.BreakCommand(time=50),
+			speech.commands.EndUtteranceCommand(),
+		]
+
+	def test_serializeByteEquality(self):
+		cases = (
+			("speak", {"sequence": self._sampleSequence()}),
+			("cancel", {}),
+			("pause_speech", {"switch": True}),
+			("tone", {"hz": 440.0, "length": 100, "left": 50, "right": 50}),
+			("wave", {"fileName": "waves/browseMode.wav"}),
+			("index", {"index": 5}),
+			("display", {"cells": [0, 1, 255]}),
+			("protocol_version", {"version": 2}),
+			("ping", {}),
+		)
+		for msgType, payload in cases:
+			with self.subTest(type=msgType):
+				self.assertEqual(
+					self.ours.serialize(type=RdMessageType(msgType), **payload),
+					self.theirs.serialize(
+						type=nvdaRemoteProtocol.RemoteMessageType(msgType),
+						**payload,
+					),
+				)
+
+	def test_crossDeserializeSpeak(self):
+		sequence = self._sampleSequence()
+		fromTheirs = self.ours.deserialize(self.theirs.serialize(type="speak", sequence=sequence))
+		self.assertEqual(fromTheirs["sequence"], sequence)
+		fromOurs = self.theirs.deserialize(self.ours.serialize(type="speak", sequence=sequence))
+		self.assertEqual(fromOurs["sequence"], sequence)


### PR DESCRIPTION
## Summary
- Replaces the pickle wire format with a JSON Lines protocol modeled on NVDA core's Remote Access (`_remoteClient`) protocol: one JSON object per line with a `type` field, message types mirroring `RemoteMessageType` where semantics match.
- Speech sequences encode byte-for-byte identically to `_remoteClient`'s `SpeechCommandJSONEncoder`. Conformance tests load `serializer.py`/`protocol.py` from the sibling NVDA source checkout and fail as soon as the NVDA Remote protocol drifts.
- Dual-stack compatibility: the receive path sniffs each message (`{` = JSON line, driverType byte = legacy frame); the send path stays legacy until the peer announces protocol version >= 2 via the new `protocolVersion` attribute pushed at connect (absent = v1). Pickle is now confined to the legacy codecs behind the existing `RestrictedUnpickler`; removal of the legacy stack is planned for a later release.
- The attribute/command machinery is now value-based: `str` attribute keys, dispatch keyed by `RdMessageType`, all protocol v1 byte formats extracted into `lib/protocol/legacy.py`.

## Testing
- 164 unit tests, including serializer round-trips and allowlist rejections, legacy golden-byte codecs, dual-stack sniffing, handshake switching, and in-process v1<->v2 peer interop.
- Manual validation against a real RDP session (settings sync, braille routing, beep/wave, say-all, old<->new version combos) still outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)