### PR TITLE
Adapt to NVDA 2026.3 braille deprecations; raise minimum to 2026.1

### DIFF
--- a/addon/brailleDisplayDrivers/remote.py
+++ b/addon/brailleDisplayDrivers/remote.py
@@ -10,15 +10,16 @@ import inputCore
 from logHandler import log
 
 if typing.TYPE_CHECKING:
-	from ..lib import detection, driver, protocol
+	from ..lib import detection, driver, nvdaCompat, protocol
 else:
 	addon: addonHandler.Addon = addonHandler.getCodeAddon()
 	detection = addon.loadModule("lib.detection")
 	driver = addon.loadModule("lib.driver")
+	nvdaCompat = addon.loadModule("lib.nvdaCompat")
 	protocol = addon.loadModule("lib.protocol")
 
 
-class RemoteBrailleDisplayDriver(driver.RemoteDriver, braille.BrailleDisplayDriver):
+class RemoteBrailleDisplayDriver(driver.RemoteDriver, nvdaCompat.BrailleDisplayDriver):
 	# Translators: Name for a remote braille display.
 	description = _("Remote Braille")
 	isThreadSafe = True

--- a/addon/globalPlugins/rdAccess/handlers/remoteBrailleHandler.py
+++ b/addon/globalPlugins/rdAccess/handlers/remoteBrailleHandler.py
@@ -15,15 +15,16 @@ from logHandler import log
 from ._remoteHandler import RemoteHandler
 
 if typing.TYPE_CHECKING:
-	from ....lib import protocol
+	from ....lib import nvdaCompat, protocol
 else:
 	import addonHandler
 
 	addon: addonHandler.Addon = addonHandler.getCodeAddon()
+	nvdaCompat = addon.loadModule("lib.nvdaCompat")
 	protocol = addon.loadModule("lib.protocol")
 
 
-class RemoteBrailleHandler(RemoteHandler[braille.BrailleDisplayDriver]):
+class RemoteBrailleHandler(RemoteHandler[nvdaCompat.BrailleDisplayDriver]):
 	driverType = protocol.DriverType.BRAILLE
 	_queuedWrite: list[int] | None = None
 	_queuedWriteLock: threading.Lock
@@ -31,16 +32,16 @@ class RemoteBrailleHandler(RemoteHandler[braille.BrailleDisplayDriver]):
 	def __init__(self, ioThread: IoThread, pipeName: str):
 		self._queuedWriteLock = threading.Lock()
 		super().__init__(ioThread, pipeName)
-		braille.decide_enabled.register(self._handleBrailleHandlerEnabled)
-		braille.displayChanged.register(self._handleDriverChanged)
+		nvdaCompat.decide_enabled.register(self._handleBrailleHandlerEnabled)
+		nvdaCompat.displayChanged.register(self._handleDriverChanged)
 		postBrailleViewerToolToggledAction.register(self._handleDisplayDimensionChanges)
 		inputCore.decide_executeGesture.register(self._handleExecuteGesture)
 
 	def terminate(self):
 		inputCore.decide_executeGesture.unregister(self._handleExecuteGesture)
 		postBrailleViewerToolToggledAction.unregister(self._handleDisplayDimensionChanges)
-		braille.displayChanged.unregister(self._handleDriverChanged)
-		braille.decide_enabled.unregister(self._handleBrailleHandlerEnabled)
+		nvdaCompat.displayChanged.unregister(self._handleDriverChanged)
+		nvdaCompat.decide_enabled.unregister(self._handleBrailleHandlerEnabled)
 		super().terminate()
 
 	def _get__driver(self):
@@ -109,14 +110,14 @@ class RemoteBrailleHandler(RemoteHandler[braille.BrailleDisplayDriver]):
 	def _handleExecuteGesture(self, gesture):
 		assert braille.handler is not None
 		if (
-			isinstance(gesture, braille.BrailleDisplayGesture)
+			isinstance(gesture, nvdaCompat.BrailleDisplayGesture)
 			and not braille.handler.enabled
 			and self.hasFocus
 		):
-			kwargs = {
+			kwargs: dict[str, typing.Any] = {
 				"source": gesture.source,
 				"id": gesture.id,
-				"routingIndex": gesture.routingIndex,
+				"routingIndex": nvdaCompat.getRoutingIndex(gesture),
 				"model": gesture.model,
 			}
 			if isinstance(gesture, brailleInput.BrailleInputGesture):
@@ -133,7 +134,7 @@ class RemoteBrailleHandler(RemoteHandler[braille.BrailleDisplayDriver]):
 	def _handleBrailleHandlerEnabled(self):
 		return not self.hasFocus
 
-	def _handleDriverChanged(self, display: braille.BrailleDisplayDriver):
+	def _handleDriverChanged(self, display: nvdaCompat.BrailleDisplayDriver):
 		self._handleDisplayDimensionChanges()
 		super()._handleDriverChanged(display)
 		self._attributeSenderStore(protocol.BrailleAttribute.GESTURE_MAP, gestureMap=display.gestureMap)

--- a/addon/globalPlugins/rdAccess/handlers/remoteBrailleHandler.py
+++ b/addon/globalPlugins/rdAccess/handlers/remoteBrailleHandler.py
@@ -32,16 +32,16 @@ class RemoteBrailleHandler(RemoteHandler[nvdaCompat.BrailleDisplayDriver]):
 	def __init__(self, ioThread: IoThread, pipeName: str):
 		self._queuedWriteLock = threading.Lock()
 		super().__init__(ioThread, pipeName)
-		nvdaCompat.decide_enabled.register(self._handleBrailleHandlerEnabled)
-		nvdaCompat.displayChanged.register(self._handleDriverChanged)
+		nvdaCompat.braille_decide_enabled.register(self._handleBrailleHandlerEnabled)
+		nvdaCompat.braille_displayChanged.register(self._handleDriverChanged)
 		postBrailleViewerToolToggledAction.register(self._handleDisplayDimensionChanges)
 		inputCore.decide_executeGesture.register(self._handleExecuteGesture)
 
 	def terminate(self):
 		inputCore.decide_executeGesture.unregister(self._handleExecuteGesture)
 		postBrailleViewerToolToggledAction.unregister(self._handleDisplayDimensionChanges)
-		nvdaCompat.displayChanged.unregister(self._handleDriverChanged)
-		nvdaCompat.decide_enabled.unregister(self._handleBrailleHandlerEnabled)
+		nvdaCompat.braille_displayChanged.unregister(self._handleDriverChanged)
+		nvdaCompat.braille_decide_enabled.unregister(self._handleBrailleHandlerEnabled)
 		super().terminate()
 
 	def _get__driver(self):

--- a/addon/globalPlugins/rdAccess/synthDetect.py
+++ b/addon/globalPlugins/rdAccess/synthDetect.py
@@ -11,15 +11,16 @@ import config
 import queueHandler
 import synthDriverHandler
 from baseObject import AutoPropertyObject
-from braille import AUTOMATIC_PORT
 from logHandler import log
 from synthDrivers.remote import remoteSynthDriver
 
 if typing.TYPE_CHECKING:
 	from ...lib import detection
+	from ...lib.nvdaCompat import AUTOMATIC_PORT
 else:
 	addon: addonHandler.Addon = addonHandler.getCodeAddon()
 	detection = addon.loadModule("lib.detection")
+	AUTOMATIC_PORT = addon.loadModule("lib.nvdaCompat").AUTOMATIC_PORT
 
 
 class SynthDetector(AutoPropertyObject):

--- a/addon/globalPlugins/rdAccess/synthDetect.py
+++ b/addon/globalPlugins/rdAccess/synthDetect.py
@@ -16,11 +16,12 @@ from synthDrivers.remote import remoteSynthDriver
 
 if typing.TYPE_CHECKING:
 	from ...lib import detection
-	from ...lib.nvdaCompat import AUTOMATIC_PORT
+	from ...lib.nvdaCompat import BRAILLE_AUTOMATIC_PORT as AUTOMATIC_PORT
 else:
 	addon: addonHandler.Addon = addonHandler.getCodeAddon()
 	detection = addon.loadModule("lib.detection")
-	AUTOMATIC_PORT = addon.loadModule("lib.nvdaCompat").AUTOMATIC_PORT
+	nvdaCompat = addon.loadModule("lib.nvdaCompat")
+	AUTOMATIC_PORT = nvdaCompat.BRAILLE_AUTOMATIC_PORT
 
 
 class SynthDetector(AutoPropertyObject):

--- a/addon/lib/namedPipe.py
+++ b/addon/lib/namedPipe.py
@@ -15,7 +15,6 @@ from ctypes.wintypes import DWORD, HANDLE
 from enum import IntFlag
 from glob import iglob
 
-import buildVersion
 import winKernel
 from hwIo.base import IoBase
 from hwIo.ioThread import IoThread
@@ -24,11 +23,7 @@ from serial.win32 import (
 	INVALID_HANDLE_VALUE,
 	CreateFile,
 )
-
-if buildVersion.version_year >= 2026:
-	from winBindings.kernel32 import PROCESSENTRY32W
-else:
-	from appModuleHandler import processEntry32W as PROCESSENTRY32W
+from winBindings.kernel32 import PROCESSENTRY32W
 
 PIPE_DIRECTORY = "\\\\.\\pipe\\"
 RD_PIPE_GLOB_PATTERN = os.path.join(PIPE_DIRECTORY, "RdPipe_NVDA-*")

--- a/addon/lib/nvdaCompat.py
+++ b/addon/lib/nvdaCompat.py
@@ -1,0 +1,65 @@
+# RDAccess: Remote Desktop Accessibility for NVDA
+# Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
+# License: GNU General Public License version 2.0
+
+"""Version-gated access to the braille symbols that moved when the ``braille`` module became a
+package in NVDA 2026.3, plus helpers that read and write a gesture's cell index across that split.
+
+On NVDA 2026.3 and later the symbols live in the ``braille.display``, ``braille.constants`` and
+``braille.extensions`` submodules, and ``BrailleDisplayGesture`` exposes ``cellIndexes`` (a list)
+in place of the deprecated single-valued ``routingIndex``. On 2026.1/2026.2 they are still reached
+through the ``braille`` facade and ``routingIndex``.
+"""
+
+from __future__ import annotations
+
+import buildVersion
+
+_BRAILLE_IS_PACKAGE = (buildVersion.version_year, buildVersion.version_major) >= (2026, 3)
+
+if _BRAILLE_IS_PACKAGE:
+	from braille.constants import AUTOMATIC_PORT
+	from braille.display.driver import BrailleDisplayDriver
+	from braille.display.gesture import BrailleDisplayGesture
+	from braille.extensions import decide_enabled, displayChanged
+else:
+	from braille import (
+		AUTOMATIC_PORT,
+		BrailleDisplayDriver,
+		BrailleDisplayGesture,
+		decide_enabled,
+		displayChanged,
+	)
+
+__all__ = (
+	"AUTOMATIC_PORT",
+	"BrailleDisplayDriver",
+	"BrailleDisplayGesture",
+	"decide_enabled",
+	"displayChanged",
+	"getRoutingIndex",
+	"applyRoutingIndex",
+)
+
+
+def getRoutingIndex(gesture: BrailleDisplayGesture) -> int | None:
+	"""Return the routing cell index addressed by ``gesture``, or ``None``.
+
+	On 2026.3+ this reads the highest entry of ``cellIndexes`` (a multi-cell gesture collapses to
+	that single index); on older versions it reads ``routingIndex`` directly.
+	"""
+	if _BRAILLE_IS_PACKAGE:
+		cellIndexes = gesture.cellIndexes
+		return max(cellIndexes) if cellIndexes else None
+	return getattr(gesture, "routingIndex", None)
+
+
+def applyRoutingIndex(gesture: BrailleDisplayGesture, routingIndex: int | None) -> None:
+	"""Store ``routingIndex`` on ``gesture`` using the attribute the running NVDA understands.
+
+	On 2026.3+ this sets ``cellIndexes``; on older versions it sets ``routingIndex``.
+	"""
+	if _BRAILLE_IS_PACKAGE:
+		gesture.cellIndexes = [routingIndex] if routingIndex is not None else None
+	else:
+		gesture.routingIndex = routingIndex

--- a/addon/lib/nvdaCompat.py
+++ b/addon/lib/nvdaCompat.py
@@ -9,6 +9,9 @@ On NVDA 2026.3 and later the symbols live in the ``braille.display``, ``braille.
 ``braille.extensions`` submodules, and ``BrailleDisplayGesture`` exposes ``cellIndexes`` (a list)
 in place of the deprecated single-valued ``routingIndex``. On 2026.1/2026.2 they are still reached
 through the ``braille`` facade and ``routingIndex``.
+
+Symbols that do not already name braille are re-exported with a ``braille``/``BRAILLE`` prefix so
+they read unambiguously through the ``nvdaCompat`` namespace.
 """
 
 from __future__ import annotations
@@ -18,25 +21,23 @@ import buildVersion
 _BRAILLE_IS_PACKAGE = (buildVersion.version_year, buildVersion.version_major) >= (2026, 3)
 
 if _BRAILLE_IS_PACKAGE:
-	from braille.constants import AUTOMATIC_PORT
+	from braille.constants import AUTOMATIC_PORT as BRAILLE_AUTOMATIC_PORT
 	from braille.display.driver import BrailleDisplayDriver
 	from braille.display.gesture import BrailleDisplayGesture
-	from braille.extensions import decide_enabled, displayChanged
+	from braille.extensions import decide_enabled as braille_decide_enabled
+	from braille.extensions import displayChanged as braille_displayChanged
 else:
-	from braille import (
-		AUTOMATIC_PORT,
-		BrailleDisplayDriver,
-		BrailleDisplayGesture,
-		decide_enabled,
-		displayChanged,
-	)
+	from braille import AUTOMATIC_PORT as BRAILLE_AUTOMATIC_PORT
+	from braille import BrailleDisplayDriver, BrailleDisplayGesture
+	from braille import decide_enabled as braille_decide_enabled
+	from braille import displayChanged as braille_displayChanged
 
 __all__ = (
-	"AUTOMATIC_PORT",
+	"BRAILLE_AUTOMATIC_PORT",
 	"BrailleDisplayDriver",
 	"BrailleDisplayGesture",
-	"decide_enabled",
-	"displayChanged",
+	"braille_decide_enabled",
+	"braille_displayChanged",
 	"getRoutingIndex",
 	"applyRoutingIndex",
 )

--- a/addon/lib/nvdaCompat.py
+++ b/addon/lib/nvdaCompat.py
@@ -24,13 +24,18 @@ if _BRAILLE_IS_PACKAGE:
 	from braille.constants import AUTOMATIC_PORT as BRAILLE_AUTOMATIC_PORT
 	from braille.display.driver import BrailleDisplayDriver
 	from braille.display.gesture import BrailleDisplayGesture
-	from braille.extensions import decide_enabled as braille_decide_enabled
-	from braille.extensions import displayChanged as braille_displayChanged
+	from braille.extensions import (
+		decide_enabled as braille_decide_enabled,
+		displayChanged as braille_displayChanged,
+	)
 else:
-	from braille import AUTOMATIC_PORT as BRAILLE_AUTOMATIC_PORT
-	from braille import BrailleDisplayDriver, BrailleDisplayGesture
-	from braille import decide_enabled as braille_decide_enabled
-	from braille import displayChanged as braille_displayChanged
+	from braille import (
+		AUTOMATIC_PORT as BRAILLE_AUTOMATIC_PORT,
+		BrailleDisplayDriver,
+		BrailleDisplayGesture,
+		decide_enabled as braille_decide_enabled,
+		displayChanged as braille_displayChanged,
+	)
 
 __all__ = (
 	"BRAILLE_AUTOMATIC_PORT",

--- a/addon/lib/protocol/braille.py
+++ b/addon/lib/protocol/braille.py
@@ -6,8 +6,7 @@ from enum import IntEnum, StrEnum
 
 import brailleInput
 
-from ..nvdaCompat import BrailleDisplayGesture as _BrailleDisplayGesture
-from ..nvdaCompat import applyRoutingIndex
+from ..nvdaCompat import BrailleDisplayGesture as _BrailleDisplayGesture, applyRoutingIndex
 
 
 class BrailleCommand(IntEnum):

--- a/addon/lib/protocol/braille.py
+++ b/addon/lib/protocol/braille.py
@@ -3,9 +3,12 @@
 # License: GNU General Public License version 2.0
 
 from enum import Enum, IntEnum
+from typing import Any
 
-import braille
 import brailleInput
+
+from ..nvdaCompat import BrailleDisplayGesture as _BrailleDisplayGesture
+from ..nvdaCompat import applyRoutingIndex, getRoutingIndex
 
 
 class BrailleCommand(IntEnum):
@@ -21,7 +24,7 @@ class BrailleAttribute(bytes, Enum):
 	OBJECT_GESTURE_MAP = b"_gestureMap"
 
 
-class BrailleInputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
+class BrailleInputGesture(_BrailleDisplayGesture, brailleInput.BrailleInputGesture):
 	def __init__(
 		self,
 		source: str,
@@ -35,9 +38,23 @@ class BrailleInputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInp
 		super().__init__()
 		self.source = source
 		self.id = id
-		self.routingIndex = routingIndex
+		applyRoutingIndex(self, routingIndex)
 		self.model = model
 		self.dots = dots
 		self.space = space
 		for attr, val in kwargs.items():
 			setattr(self, attr, val)
+
+	def __getstate__(self) -> dict[str, Any]:
+		# Carry the routing cell on the wire under a version-neutral key so the receiving NVDA can
+		# rebuild whichever of routingIndex/cellIndexes it understands.
+		state = self.__dict__.copy()
+		for key in ("_propertyCache", "cellIndexes", "routingIndex"):
+			state.pop(key, None)
+		state["_wireRoutingIndex"] = getRoutingIndex(self)
+		return state
+
+	def __setstate__(self, state: dict[str, Any]) -> None:
+		routingIndex = state.pop("_wireRoutingIndex", None)
+		self.__dict__.update(state)
+		applyRoutingIndex(self, routingIndex)

--- a/addon/synthDrivers/remote.py
+++ b/addon/synthDrivers/remote.py
@@ -19,12 +19,13 @@ from logHandler import log
 
 if typing.TYPE_CHECKING:
 	from ..lib import driver, protocol
-	from ..lib.nvdaCompat import AUTOMATIC_PORT
+	from ..lib.nvdaCompat import BRAILLE_AUTOMATIC_PORT as AUTOMATIC_PORT
 else:
 	addon: addonHandler.Addon = addonHandler.getCodeAddon()
 	driver = addon.loadModule("lib.driver")
 	protocol = addon.loadModule("lib.protocol")
-	AUTOMATIC_PORT = addon.loadModule("lib.nvdaCompat").AUTOMATIC_PORT
+	nvdaCompat = addon.loadModule("lib.nvdaCompat")
+	AUTOMATIC_PORT = nvdaCompat.BRAILLE_AUTOMATIC_PORT
 
 
 class remoteSynthDriver(driver.RemoteDriver, synthDriverHandler.SynthDriver):

--- a/addon/synthDrivers/remote.py
+++ b/addon/synthDrivers/remote.py
@@ -14,7 +14,6 @@ import synthDriverHandler
 import tones
 from autoSettingsUtils.driverSetting import DriverSetting
 from autoSettingsUtils.utils import StringParameterInfo
-from braille import AUTOMATIC_PORT
 from extensionPoints import Action
 from hwIo import boolToByte
 from languageHandler import getLanguage
@@ -22,10 +21,12 @@ from logHandler import log
 
 if typing.TYPE_CHECKING:
 	from ..lib import driver, protocol
+	from ..lib.nvdaCompat import AUTOMATIC_PORT
 else:
 	addon: addonHandler.Addon = addonHandler.getCodeAddon()
 	driver = addon.loadModule("lib.driver")
 	protocol = addon.loadModule("lib.protocol")
+	AUTOMATIC_PORT = addon.loadModule("lib.nvdaCompat").AUTOMATIC_PORT
 
 
 class remoteSynthDriver(driver.RemoteDriver, synthDriverHandler.SynthDriver):

--- a/buildVars.py
+++ b/buildVars.py
@@ -43,7 +43,7 @@ addon_info = AddonInfo(
 	# Documentation file name
 	addon_docFileName="readme.html",
 	# Minimum NVDA version supported (e.g. "2019.3.0", minor version is optional)
-	addon_minimumNVDAVersion="2025.1",
+	addon_minimumNVDAVersion="2026.1",
 	# Last NVDA version supported/tested (e.g. "2024.4.0", ideally more recent than minimum version)
 	addon_lastTestedNVDAVersion="2026.1",
 	# Add-on update channel (default is None, denoting stable releases,

--- a/buildVars.py
+++ b/buildVars.py
@@ -45,7 +45,7 @@ addon_info = AddonInfo(
 	# Minimum NVDA version supported (e.g. "2019.3.0", minor version is optional)
 	addon_minimumNVDAVersion="2026.1",
 	# Last NVDA version supported/tested (e.g. "2024.4.0", ideally more recent than minimum version)
-	addon_lastTestedNVDAVersion="2026.1",
+	addon_lastTestedNVDAVersion="2026.3",
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,9 @@ select = [
 # so unused arguments are expected.
 "tests/**" = ["ARG002"]
 
+[tool.ruff.lint.isort]
+combine-as-imports = true
+
 [tool.ty.environment]
 python-version = "3.13"
 # The add-on only runs on Windows; analyse the win32 code paths even on a Linux/macOS checkout.

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 * Authors: [Leonard de Ruijter][1]
 * Download [latest stable version][2]
-* NVDA compatibility: 2024.1 and later
+* NVDA compatibility: 2026.1 and later
 
 The RDAccess add-on (Remote Desktop Accessibility) adds support for Microsoft Remote Desktop, Citrix, Parallels RAS, or VMware Horizon remote sessions to NVDA.
 When installed on both the client and the server in NVDA, speech and braille generated on the server will be spoken and displayed in braille on the client machine.
@@ -21,6 +21,11 @@ This enables a user experience where managing a remote system feels as seamless 
 * Ability to control specific synthesizer and braille display settings without leaving the remote session
 
 ## Changelog
+
+### Version 1.7.2
+
+* The minimum compatible NVDA version is now 2026.1. Removed support for earlier versions.
+* Adapted to the braille API changes and deprecations introduced in NVDA 2026.3.
 
 ### Version 1.7.1
 

--- a/tests/_stubs.py
+++ b/tests/_stubs.py
@@ -123,12 +123,43 @@ def install():
 
 	hwIoBase.IoBase = IoBase
 
+	buildVersion = _module("buildVersion")
+	buildVersion.version_year = 2026
+	buildVersion.version_major = 3
+
 	braille = _module("braille")
+	brailleDisplay = _module("braille.display")
+	braille.display = brailleDisplay
+	brailleDisplayGesture = _module("braille.display.gesture")
+	brailleDisplay.gesture = brailleDisplayGesture
+	brailleDisplayDriver = _module("braille.display.driver")
+	brailleDisplay.driver = brailleDisplayDriver
+	brailleConstants = _module("braille.constants")
+	braille.constants = brailleConstants
+	brailleExtensions = _module("braille.extensions")
+	braille.extensions = brailleExtensions
 
 	class BrailleDisplayGesture:
+		cellIndexes: list[int] | None = None
+
+		@property
+		def routingIndex(self) -> int | None:
+			return max(self.cellIndexes) if self.cellIndexes else None
+
+		@routingIndex.setter
+		def routingIndex(self, value: int | None) -> None:
+			self.cellIndexes = [value] if value is not None else None
+
+	brailleDisplayGesture.BrailleDisplayGesture = BrailleDisplayGesture
+
+	class BrailleDisplayDriver:
 		pass
 
-	braille.BrailleDisplayGesture = BrailleDisplayGesture
+	brailleDisplayDriver.BrailleDisplayDriver = BrailleDisplayDriver
+
+	brailleConstants.AUTOMATIC_PORT = ("auto", "Automatic")
+	brailleExtensions.decide_enabled = object()
+	brailleExtensions.displayChanged = object()
 
 	brailleInput = _module("brailleInput")
 

--- a/tests/test_restrictedUnpickling.py
+++ b/tests/test_restrictedUnpickling.py
@@ -167,6 +167,7 @@ class TestRestrictedUnpicklingAcceptance(unittest.TestCase):
 		restored = self._roundtrip(original)
 		self.assertIsInstance(restored, BrailleInputGesture)
 		self.assertEqual(restored.id, "routing1")
+		self.assertEqual(restored.cellIndexes, [3])
 		self.assertEqual(restored.routingIndex, 3)
 
 	def test_roundtrips_plain_builtins_dict(self):

--- a/tests/test_serializerConformance.py
+++ b/tests/test_serializerConformance.py
@@ -17,8 +17,7 @@ import speech.commands
 from lib.protocol import serializer as rdSerializer
 from lib.protocol.messages import RdMessageType
 
-from ._nvdaRemote import protocol as nvdaRemoteProtocol
-from ._nvdaRemote import serializer as nvdaRemoteSerializer
+from ._nvdaRemote import protocol as nvdaRemoteProtocol, serializer as nvdaRemoteSerializer
 
 
 class MessageTypeConformanceTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adapts RDAccess to the braille API changes and deprecations introduced in NVDA 2026.3,
integrated on top of the protocol v2 (JSON Lines) work. The `braille` module became a
package in 2026.3, moving several symbols and deprecating
`BrailleDisplayGesture.routingIndex` in favour of `cellIndexes` (a list).

## Changes

- **New `addon/lib/nvdaCompat.py`** — a single version gate
  (`(version_year, version_major) >= (2026, 3)`) that re-exports the moved symbols
  (`BrailleDisplayGesture`, `BrailleDisplayDriver`, `AUTOMATIC_PORT`, `decide_enabled`,
  `displayChanged`) and provides `getRoutingIndex`/`applyRoutingIndex` helpers hiding the
  `routingIndex` <-> `cellIndexes` difference.
- All consumers (`protocol/braille`, `remoteBrailleHandler`, `brailleDisplayDrivers/remote`,
  `synthDrivers/remote`, `synthDetect`) go through the compat module instead of the
  deprecated `braille.*` facade.
- `BrailleInputGesture` sets routing via `applyRoutingIndex` (on 2026.3 this sets
  `cellIndexes`, so executed gestures route correctly and the deprecated `routingIndex`
  setter is never hit). No custom pickle hooks: protocol v2 carries `routingIndex` as a
  plain JSON field, and the legacy pickle path only needs `routingIndex` (cellIndexes-capable
  peers negotiate v2).
- The server-side read of a real gesture's routing now uses `getRoutingIndex`, fixing an
  `AttributeError` on 2026.3 when deprecated API access is disabled.
- Minimum NVDA raised to **2026.1**, which lets the `PROCESSENTRY32W` version gate in
  `namedPipe` become an unconditional import.

## Testing

- `uv run ty check` — clean.
- `uv run python -m unittest discover -s tests -t .` — 164 tests pass.
- `uv run prek run --all-files` — passes.
- :warning: **Manual testing still required:** the 2026.1/2026.2 (facade) branch has no
  automated coverage. Needs a smoke test on a real 2026.1 install (routing key press) and a
  mixed-version RDP/Citrix session (e.g. 2026.1 <-> 2026.3) to exercise routing keys.

Note: multi-cell routing gestures collapse to a single index on the wire — not a regression
(the wire was always single-index and multi-routing was never forwarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)