### PR TITLE
Initialize remote drivers on XON instead of the full attribute handshake

### DIFF
--- a/addon/brailleDisplayDrivers/remote.py
+++ b/addon/brailleDisplayDrivers/remote.py
@@ -25,8 +25,8 @@ class RemoteBrailleDisplayDriver(driver.RemoteDriver, nvdaCompat.BrailleDisplayD
 	isThreadSafe = True
 	supportsAutomaticDetection = True
 	driverType = protocol.DriverType.BRAILLE
-	_requiredAttributesOnInit = frozenset(
-		driver.RemoteDriver._requiredAttributesOnInit.union({
+	_attributesToPreRequestOnInit = frozenset(
+		driver.RemoteDriver._attributesToPreRequestOnInit.union({
 			protocol.BrailleAttribute.NUM_CELLS,
 		}),
 	)
@@ -68,6 +68,15 @@ class RemoteBrailleDisplayDriver(driver.RemoteDriver, nvdaCompat.BrailleDisplayD
 
 	def _get_numCols(self) -> int:
 		return self._getRemoteAttributeValueWithFallback(protocol.BrailleAttribute.NUM_COLS)
+
+	@_incoming_numCells.updateCallback
+	@_incoming_numRows.updateCallback
+	@_incoming_numCols.updateCallback
+	def _updateCallback_displayDimensions(self, _attribute: protocol.AttributeT, _value: int):
+		self.invalidateCache()
+		assert braille.handler is not None
+		if braille.handler.display is self:
+			self._queueFunctionOnMainThread(braille.handler.initialDisplay)
 
 	_incoming_gestureMapUpdate = protocol.AttributeReceiver(protocol.BrailleAttribute.GESTURE_MAP)
 

--- a/addon/lib/driver/__init__.py
+++ b/addon/lib/driver/__init__.py
@@ -3,7 +3,6 @@
 # License: GNU General Public License version 2.0 or later
 from __future__ import annotations
 
-import time
 from abc import abstractmethod
 from collections.abc import Iterable, Iterator, Sequence
 from typing import Any, ClassVar
@@ -31,7 +30,7 @@ ERROR_PIPE_NOT_CONNECTED = 0xE9
 class RemoteDriver(protocol.RemoteProtocolHandler, driverHandler.Driver):
 	name = "remote"
 	_settingsAccessor: SettingsAccessorBase | None = None
-	_requiredAttributesOnInit: frozenset[protocol.AttributeT] = frozenset({
+	_attributesToPreRequestOnInit: frozenset[protocol.AttributeT] = frozenset({
 		protocol.GenericAttribute.SUPPORTED_SETTINGS,
 	})
 
@@ -65,11 +64,10 @@ class RemoteDriver(protocol.RemoteProtocolHandler, driverHandler.Driver):
 		self._saveSpecificSettings(self, self._localSettings)
 
 	def __init__(self, port="auto"):
-		initialTime = time.perf_counter()
 		super().__init__()
 		self._connected = False
 		for _portType, _portId, port, _portInfo in self._getTryPorts(port):  # noqa: B020
-			for attr in self._requiredAttributesOnInit:
+			for attr in self._attributesToPreRequestOnInit:
 				self._attributeValueProcessor.setAttributeRequestPending(attr)
 			try:
 				self._dev = wtsVirtualChannel.WTSVirtualChannel(
@@ -81,21 +79,8 @@ class RemoteDriver(protocol.RemoteProtocolHandler, driverHandler.Driver):
 				log.debugWarning("", exc_info=True)
 				continue
 			# Wait for RdPipe at the other end to send a XON
-			if not self._safeWait(lambda: self._connected, self.timeout * 3):
-				continue
-			handledAttributes = set[protocol.AttributeT]()
-			for attr in self._requiredAttributesOnInit:
-				if self._waitForAttributeUpdate(attr, initialTime):
-					handledAttributes.add(attr)
-				else:
-					log.debugWarning(f"Error getting {attr}")
-
-			else:
-				if not (self._requiredAttributesOnInit - handledAttributes):
-					log.debug(f"Required attributes received: {handledAttributes!r}")
-					break
-
-			self._dev.close()
+			if self._safeWait(lambda: self._connected, self.timeout * 3):
+				break
 		else:
 			raise RuntimeError("No remote device found")
 
@@ -162,13 +147,10 @@ class RemoteDriver(protocol.RemoteProtocolHandler, driverHandler.Driver):
 		self.invalidateCache()
 
 	def _get_supportedSettings(self):
-		settings = []
-		settings.extend(self._localSettings)
-		attribute = protocol.GenericAttribute.SUPPORTED_SETTINGS
-		try:
-			settings.extend(self._attributeValueProcessor.getValue(attribute, fallBackToDefault=False))
-		except KeyError:
-			settings.extend(self.getRemoteAttribute(attribute))
+		settings = list(self._localSettings)
+		settings.extend(
+			self._getRemoteAttributeValueWithFallback(protocol.GenericAttribute.SUPPORTED_SETTINGS),
+		)
 		return settings
 
 	_incoming_setting = protocol.AttributeReceiver(protocol.SETTING_ATTRIBUTE_PREFIX + "*")

--- a/addon/synthDrivers/remote.py
+++ b/addon/synthDrivers/remote.py
@@ -16,6 +16,7 @@ from autoSettingsUtils.utils import StringParameterInfo
 from extensionPoints import Action
 from languageHandler import getLanguage
 from logHandler import log
+from speech.commands import IndexCommand
 
 if typing.TYPE_CHECKING:
 	from ..lib import driver, protocol
@@ -61,6 +62,10 @@ class remoteSynthDriver(driver.RemoteDriver, synthDriverHandler.SynthDriver):
 		super().__init__(port)
 		nvwave.decide_playWaveFile.register(self.handle_decidePlayWaveFile)
 		tones.decide_beep.register(self.handle_decideBeep)
+
+	def initSettings(self):
+		super().initSettings()
+		synthDriverHandler.changeVoice(self, None)
 
 	def terminate(self):
 		tones.decide_beep.unregister(self.handle_decideBeep)
@@ -110,7 +115,7 @@ class remoteSynthDriver(driver.RemoteDriver, synthDriverHandler.SynthDriver):
 
 	_incoming_supportedCommands = protocol.AttributeReceiver(
 		protocol.SpeechAttribute.SUPPORTED_COMMANDS,
-		defaultValue=frozenset(),
+		defaultValue=frozenset({IndexCommand}),
 	)
 
 	def _get_supportedCommands(self):

--- a/changelog.md
+++ b/changelog.md
@@ -1,1 +1,2 @@
 Hopefully fixed a bug in rd_pipe that caused the wrong virtual channel to be created.
+The remote synthesizer and braille display drivers now initialize as soon as the channel is established, rather than waiting for the full attribute handshake. This makes connecting and reconnecting more reliable.


### PR DESCRIPTION
### Summary of the issue

`RemoteDriver.__init__` blocked until XON **and** every attribute in `_requiredAttributesOnInit`
arrived (`SUPPORTED_SETTINGS`; braille also `NUM_CELLS`). When attributes were slow or absent (e.g.
across an RDP reconnect), init failed the port over and could raise
`RuntimeError("No remote device found")` even though the channel itself was up. XON is already the
real readiness signal: rd_pipe writes it only after the pipe client has attached, so the client's
proactive attribute push is guaranteed to be in flight by the time it is received.

### Description of the changes

* `RemoteDriver.__init__` breaks out of the port loop as soon as XON is received. Attributes are
  still pre-marked pending (`_attributesToPreRequestOnInit`, renamed from
  `_requiredAttributesOnInit`) so the client's push is recognized without a duplicate request.
* `_get_supportedSettings` uses `_getRemoteAttributeValueWithFallback` like every other remote
  attribute getter. The previously dead blocking branch (`getRemoteAttribute`, up to 1 s on the main
  thread) would have been revived by XON-only init.
* The braille driver re-runs `braille.handler.initialDisplay` when any dimension attribute
  (`NUM_CELLS`/`NUM_ROWS`/`NUM_COLS`) arrives: the 0→N cell transition does not repaint by itself,
  since the `initialDisplay` queued by `_setDisplay` runs before the dimensions land and
  early-returns while the handler is disabled.
* The synth driver binds the settings ring on `initSettings` via `changeVoice`, matching what core
  synths do, so the ring is never left bound to the previous synth while settings are in flight.
  `supportedCommands` defaults to `IndexCommand` until the real set arrives.

Adversarially traced against NVDA core (setSynth aftermath, speech manager, settings ring, bdDetect,
0-cell write paths, termination races, config profile switches) — no blocking or crashing paths
remain during the attribute window. Known accepted residual: in nested session chains, a
`synthChanged` that fires inside the window propagates fallback-only settings down-chain until the
next `synthChanged`; speech itself is unaffected.

### Testing strategy

Unit tests and lint/type checks pass. Manual verification against a live RDP session planned:
fresh connect (braille paints without moving focus), RDP disconnect/reconnect, settings ring
immediately after connect, switching to Remote Braille from the display dialog mid-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
