### PR TITLE
Fix remote braille display selection and initial braille output

### DIFF
--- a/addon/brailleDisplayDrivers/remote.py
+++ b/addon/brailleDisplayDrivers/remote.py
@@ -73,10 +73,15 @@ class RemoteBrailleDisplayDriver(driver.RemoteDriver, nvdaCompat.BrailleDisplayD
 	@_incoming_numRows.updateCallback
 	@_incoming_numCols.updateCallback
 	def _updateCallback_displayDimensions(self, _attribute: protocol.AttributeT, _value: int):
-		self.invalidateCache()
+		self._queueFunctionOnMainThread(self._handleDisplayDimensionsChanged)
+
+	def _handleDisplayDimensionsChanged(self):
 		assert braille.handler is not None
-		if braille.handler.display is self:
-			self._queueFunctionOnMainThread(braille.handler.initialDisplay)
+		if braille.handler.display is not self:
+			return
+		self.invalidateCache()
+		braille.handler.invalidateCache()
+		braille.handler.initialDisplay()
 
 	_incoming_gestureMapUpdate = protocol.AttributeReceiver(protocol.BrailleAttribute.GESTURE_MAP)
 

--- a/addon/lib/driver/__init__.py
+++ b/addon/lib/driver/__init__.py
@@ -49,7 +49,6 @@ class RemoteDriver(protocol.RemoteProtocolHandler, driverHandler.Driver):
 		if isinstance(port, bdDetect.DeviceMatch):
 			yield port
 		else:
-			assert port == "auto"
 			yield from cls._getAutoPorts()
 
 	_localSettings: ClassVar[list[DriverSetting]] = []


### PR DESCRIPTION
Two follow-ups to #67 (XON-only remote driver init).

### 1. Selecting the remote braille display no longer crashes

The braille display confspec defines `[[__many__]] port = string(default="")`, so
`config.conf["braille"]["remote"]["port"]` returns `""` (not a `KeyError`). NVDA passes that to
`__init__` whenever the display is set **without** a detected device — e.g. when "Remote Braille" is
picked manually in the Braille Settings dialog, or `display=remote` comes from a config profile.
`_getTryPorts` then hit `assert port == "auto"`, which aborted initialization and fell the handler
back to no braille. (Automatic detection was unaffected, because `bdDetect` always passes a
`DeviceMatch`.)

The remote driver has no manual hardware ports, so `_getTryPorts` now ignores any non-`DeviceMatch`
port value and uses automatic detection.

### 2. The first line of braille is now shown on connect

The display-dimensions update callback fires on the background attribute executor, which can run
**before** `braille.handler.display` has been assigned to the new driver — remote init runs on the
detection thread and pumps channel reads while waiting for XON, so the required attributes can arrive
mid-init. The old `braille.handler.display is self` guard therefore saw the *previous* display and
skipped showing braille.

The check and showing braille are now deferred to the main thread, where `display` is already
assigned. The handler also has its own cache invalidated (separate from the driver's) so
`initialDisplay` recomputes the now-enabled state instead of reading the stale disabled one.

### Testing

Unit tests, ruff and ty pass. Manual verification against a live RDP session: select "Remote
Braille" manually (no crash), and confirm the first line of braille is shown on connect without
moving focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
