### PR TITLE
Fix crash when reinitializing the remote driver from the display dialog

### DIFF
--- a/addon/lib/driver/__init__.py
+++ b/addon/lib/driver/__init__.py
@@ -97,9 +97,12 @@ class RemoteDriver(protocol.RemoteProtocolHandler, driverHandler.Driver):
 
 	def __setattr__(self, name: str, value: Any) -> None:
 		getter = super().__getattribute__
-		accessor = getter("_settingsAccessor")
-		if accessor and getter("isSupported")(name):
-			setattr(accessor, name, value)
+		if not (
+			(name.startswith("_") and not name.startswith("_get_")) or name in _AUTO_PROPERTY_OBJECT_NAMES
+		):
+			accessor = getter("_settingsAccessor")
+			if accessor and getter("isSupported")(name):
+				setattr(accessor, name, value)
 		super().__setattr__(name, value)
 
 	def _onReadError(self, error: int) -> bool:


### PR DESCRIPTION
### The problem

Re-selecting "Remote Braille" while it is already the active display crashed with
`OSError: [WinError 6] The handle is invalid`, dropping braille back to no braille:

```
File "lib\driver\__init__.py", line 66, in __init__
  super().__init__()
File "lib\protocol\__init__.py", line 396, in __init__
  self._bgExecutor = ThreadPoolExecutor(4, ...)
File "lib\driver\__init__.py", line 101, in __setattr__
  if accessor and getter("isSupported")(name):
...
File "lib\protocol\__init__.py", line 538, in sendMessage
  self._dev.write(...)
OSError: [WinError 6] The handle is invalid.
```

### Root cause

`RemoteDriver.__getattribute__` skips the settings-accessor routing for private and auto-property
names, but `__setattr__` did not. So assigning *any* private attribute ran `isSupported()` →
`self.supportedSettings`, which does remote I/O.

- On a **fresh** display selection a new instance is built, so `_settingsAccessor` is still `None`
  and the `if accessor and …` guard short-circuits — no I/O.
- On a **reinit of the already-active display**, `_switchDisplay` reuses the same instance
  (`sameDisplayReInit`). `terminate()` has already closed the channel and cleared the processor's
  stored attribute values, but `_settingsAccessor` is never reset, so it is still non-`None`.
  Assigning `_bgExecutor` in `super().__init__()` then evaluated `supportedSettings`, found
  `SUPPORTED_SETTINGS` missing, requested it, and wrote to the closed handle → `WinError 6`.

This predates #67/#68 — `__setattr__` and the `super().__init__()` ordering are older, and the
previous `_get_supportedSettings` wrote on the same path.

### Fix

Mirror the `__getattribute__` guard in `__setattr__`: private and auto-property names never route
through the accessor. This fixes the reinit crash for both the braille and synth drivers, and avoids
a `supportedSettings` lookup on every private assignment (e.g. per received chunk). The stale
`_settingsAccessor` is harmless — it is rebuilt when `SUPPORTED_SETTINGS` re-arrives.

### Testing

Unit tests, ruff and ty pass. Manual verification against a live RDP session: re-select "Remote
Braille" from the Select Braille Display dialog while it is already active — it re-initializes
instead of crashing to no braille.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
