### PR TITLE
Show remote braille on cold start without waiting for input

### DIFF
--- a/addon/lib/driver/__init__.py
+++ b/addon/lib/driver/__init__.py
@@ -25,11 +25,14 @@ _AUTO_PROPERTY_OBJECT_NAMES: frozenset[str] = frozenset(
 
 ERROR_INVALID_HANDLE = 0x6
 ERROR_PIPE_NOT_CONNECTED = 0xE9
+# Milliseconds after connecting during which time since input is reported as zero.
+CONNECT_FOCUS_GRACE = 4000
 
 
 class RemoteDriver(protocol.RemoteProtocolHandler, driverHandler.Driver):
 	name = "remote"
 	_settingsAccessor: SettingsAccessorBase | None = None
+	_connectTick: int = 0
 	_attributesToPreRequestOnInit: frozenset[protocol.AttributeT] = frozenset({
 		protocol.GenericAttribute.SUPPORTED_SETTINGS,
 	})
@@ -120,6 +123,7 @@ class RemoteDriver(protocol.RemoteProtocolHandler, driverHandler.Driver):
 			command = message[0]
 			if command == protocol.MSG_XON:
 				self._connected = True
+				self._connectTick = inputTime.getTickCount()
 				self.pushProtocolVersion()
 				return
 			elif command == protocol.MSG_XOFF:
@@ -160,6 +164,8 @@ class RemoteDriver(protocol.RemoteProtocolHandler, driverHandler.Driver):
 
 	@protocol.attributeSender(protocol.GenericAttribute.TIME_SINCE_INPUT)
 	def _outgoing_timeSinceInput(self) -> int:
+		if inputTime.getTickCount() - self._connectTick < CONNECT_FOCUS_GRACE:
+			return 0
 		return inputTime.getTimeSinceInput()
 
 	def _handlePossibleSessionDisconnect(self):


### PR DESCRIPTION
### The problem

On a cold start of NVDA in a remote session, no braille reaches the physical display until the first
focus change / key press.

### Root cause

The client only writes the server's cells to the local display when it considers the remote session
focused. That decision (`_remoteHandler._get_hasFocus` / `_post_timeSinceInput`) is driven by the
server's reported time since input: the session is treated as focused only when it is `<= 200 ms`.
This is what disambiguates *which* session the user is driving when several are connected.

On a cold start the session is idle, so the server reports a large time since input, the client
treats it as unfocused, and every `DISPLAY` message is queued and dropped. Confirmed from a paired
client log — the server reported `2422, 2547, 3265, 4265` ms while braille stayed blank, then `141`
ms the moment the user pressed a key, at which point the queued cells were written.

### The change

`RemoteDriver` records the tick count on each `MSG_XON` and reports a time since input of `0` for a
grace period (`CONNECT_FOCUS_GRACE = 4000` ms) afterwards. A freshly connected, still-idle session
therefore reads as focused and its first cells are shown immediately, with no user input required.
After the grace period the real OS input time takes over, so the per-session focus disambiguation is
preserved and the wrong-session risk (a session that reconnects idle in the background) is bounded to
that window.

Server-side only; the client focus logic is unchanged.

### Testing strategy

Manually tested against a live RDP session: cold-start NVDA in the session and confirm braille
appears within the grace window without any keypress, and that per-session behaviour still resolves
correctly once input starts. Unit tests, ruff and ty pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
