### PR TITLE
When queuing calls to the main thread which present speech or braille to the user, ensure they are executed immediately.

### DIFF
--- a/addon/globalPlugins/rdAccess/handlers/remoteBrailleHandler.py
+++ b/addon/globalPlugins/rdAccess/handlers/remoteBrailleHandler.py
@@ -93,7 +93,7 @@ class RemoteBrailleHandler(RemoteHandler[nvdaCompat.BrailleDisplayDriver]):
 			with self._queuedWriteLock:
 				self._queuedWrite = cells
 			if not braille.handler.enabled and self.hasFocus:
-				self._queueFunctionOnMainThread(self._performLocalWriteCells)
+				self._queueFunctionOnMainThread(self._performLocalWriteCells, _immediate=True)
 			elif self._remoteSessionhasFocus is False:
 				self.requestRemoteAttribute(protocol.GenericAttribute.TIME_SINCE_INPUT)
 
@@ -107,7 +107,7 @@ class RemoteBrailleHandler(RemoteHandler[nvdaCompat.BrailleDisplayDriver]):
 
 	def _handleRemoteSessionGainFocus(self):
 		super()._handleRemoteSessionGainFocus()
-		self._queueFunctionOnMainThread(self._performLocalWriteCells)
+		self._queueFunctionOnMainThread(self._performLocalWriteCells, _immediate=True)
 
 	def _handleExecuteGesture(self, gesture):
 		assert braille.handler is not None

--- a/addon/globalPlugins/rdAccess/handlers/remoteSpeechHandler.py
+++ b/addon/globalPlugins/rdAccess/handlers/remoteSpeechHandler.py
@@ -60,7 +60,7 @@ class RemoteSpeechHandler(RemoteHandler[synthDriverHandler.SynthDriver]):
 
 	@protocol.commandHandler(protocol.RdMessageType.SPEAK)
 	def _command_speak(self, sequence: SpeechSequence):
-		self._queueFunctionOnMainThread(self._speak, sequence)
+		self._queueFunctionOnMainThread(self._speak, sequence, _immediate=True)
 
 	def _speak(self, sequence: SpeechSequence):
 		pitchChange = configuration.getIncomingSpeechPitchChange(fromCache=True)
@@ -80,7 +80,7 @@ class RemoteSpeechHandler(RemoteHandler[synthDriverHandler.SynthDriver]):
 	@protocol.commandHandler(protocol.RdMessageType.CANCEL)
 	def _command_cancel(self):
 		self._indexesSpeaking.clear()
-		self._queueFunctionOnMainThread(self._cancel)
+		self._queueFunctionOnMainThread(self._cancel, _immediate=True)
 
 	def _cancel(self):
 		self._driver.cancel()
@@ -90,7 +90,7 @@ class RemoteSpeechHandler(RemoteHandler[synthDriverHandler.SynthDriver]):
 
 	@protocol.commandHandler(protocol.RdMessageType.PAUSE_SPEECH)
 	def _command_pause(self, switch: bool):
-		self._queueFunctionOnMainThread(self._pause, switch)
+		self._queueFunctionOnMainThread(self._pause, switch, _immediate=True)
 
 	def _pause(self, switch: bool):
 		speech.pauseSpeech(switch)


### PR DESCRIPTION
By default, functions queued with queueHandler.queueFunction are delayed slightly so that queues can implement rate limiting, filter extraneous events, etc. Any of that has already occurred on the server.
Therefore, on the client, we want output to be presented to the user as soon as possible; there's no benefit in delaying further. This should make speech and braille output from the server feel more responsive.