### PR TITLE
Keep remote speech active across config profile switches

### DIFF
--- a/addon/globalPlugins/rdAccess/settingsPanel.py
+++ b/addon/globalPlugins/rdAccess/settingsPanel.py
@@ -58,9 +58,9 @@ class RemoteDesktopSettingsPanel(SettingsPanel):
 		serverGroup = guiHelper.BoxSizerHelper(self, sizer=serverGroupSizer)  # ty: ignore[invalid-argument-type]
 		sizer_helper.addItem(serverGroup)
 
-		# Translators: The label for a setting in RDAccess settings to enable
-		# automatic recovery of remote speech when the connection was lost.
-		recoverRemoteSpeechText = _("&Automatically recover remote speech after connection loss")
+		# Translators: The label for a setting in RDAccess settings to let NVDA
+		# activate remote speech whenever a remote session offers it.
+		recoverRemoteSpeechText = _("&Automatically switch to remote speech when available")
 		self.recoverRemoteSpeechCheckbox = serverGroup.addItem(
 			wx.CheckBox(serverGroupBox, label=recoverRemoteSpeechText),
 		)

--- a/addon/globalPlugins/rdAccess/synthDetect.py
+++ b/addon/globalPlugins/rdAccess/synthDetect.py
@@ -69,6 +69,7 @@ class SynthDetector(AutoPropertyObject):
 		original = synthDriverHandler.handlePostConfigProfileSwitch
 		if not config.post_configProfileSwitch.unregister(original):
 			log.debugWarning("NVDA's synthesizer profile switch handler was not registered")
+			return
 		self._nvdaHandlePostConfigProfileSwitch = original
 		handler = self._handlePostConfigProfileSwitch
 		config.post_configProfileSwitch.register(handler)

--- a/addon/globalPlugins/rdAccess/synthDetect.py
+++ b/addon/globalPlugins/rdAccess/synthDetect.py
@@ -26,8 +26,8 @@ else:
 
 
 class SynthDetector(AutoPropertyObject):
-	#: NVDA's own synthesizer profile switch handler, while replaced by ours.
 	_nvdaHandlePostConfigProfileSwitch: Callable[[bool], None] | None = None
+	"""NVDA's own synthesizer profile switch handler, while replaced by ours."""
 
 	def __init__(self):
 		remoteSynthDriver.synthRemoteDisconnected.register(self._handleRemoteDisconnect)

--- a/addon/globalPlugins/rdAccess/synthDetect.py
+++ b/addon/globalPlugins/rdAccess/synthDetect.py
@@ -4,6 +4,7 @@
 
 import threading
 import typing
+from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 
 import addonHandler
@@ -25,11 +26,15 @@ else:
 
 
 class SynthDetector(AutoPropertyObject):
+	#: NVDA's own synthesizer profile switch handler, while replaced by ours.
+	_nvdaHandlePostConfigProfileSwitch: Callable[[bool], None] | None = None
+
 	def __init__(self):
 		remoteSynthDriver.synthRemoteDisconnected.register(self._handleRemoteDisconnect)
 		self._executor = ThreadPoolExecutor(1, thread_name_prefix=self.__class__.__name__)
 		self._queuedFuture: Future | None = None
 		self._stopEvent = threading.Event()
+		self._takeOverPostConfigProfileSwitch()
 
 	currentSynthesizer: synthDriverHandler.SynthDriver
 
@@ -53,6 +58,45 @@ class SynthDetector(AutoPropertyObject):
 	def _get_isRemoteSynthConfigured(self):
 		assert config.conf is not None
 		return config.conf[remoteSynthDriver._configSection]["synth"] == remoteSynthDriver.name
+
+	def _takeOverPostConfigProfileSwitch(self):
+		"""Puts our own handler in NVDA's place, both on L{config.post_configProfileSwitch}
+		and as L{synthDriverHandler.handlePostConfigProfileSwitch},
+		at the start of the registration order.
+		"""
+		if self._nvdaHandlePostConfigProfileSwitch is not None:
+			return
+		original = synthDriverHandler.handlePostConfigProfileSwitch
+		if not config.post_configProfileSwitch.unregister(original):
+			log.debugWarning("NVDA's synthesizer profile switch handler was not registered")
+		self._nvdaHandlePostConfigProfileSwitch = original
+		handler = self._handlePostConfigProfileSwitch
+		config.post_configProfileSwitch.register(handler)
+		config.post_configProfileSwitch.moveToEnd(handler, last=False)
+		synthDriverHandler.handlePostConfigProfileSwitch = handler  # ty: ignore[invalid-assignment]
+
+	def _restorePostConfigProfileSwitch(self):
+		"""Reverses L{_takeOverPostConfigProfileSwitch}.
+		The module attribute is only restored when it still holds our handler.
+		"""
+		original = self._nvdaHandlePostConfigProfileSwitch
+		if original is None:
+			return
+		self._nvdaHandlePostConfigProfileSwitch = None
+		handler = self._handlePostConfigProfileSwitch
+		config.post_configProfileSwitch.unregister(handler)
+		config.post_configProfileSwitch.register(original)
+		config.post_configProfileSwitch.moveToEnd(original, last=False)
+		if synthDriverHandler.handlePostConfigProfileSwitch != handler:
+			return
+		synthDriverHandler.handlePostConfigProfileSwitch = original  # ty: ignore[invalid-assignment]
+
+	def _handlePostConfigProfileSwitch(self, resetSpeechIfNeeded: bool = True):
+		"""Skips NVDA's synthesizer reload while remote speech is active without being configured."""
+		if self.isRemoteSynthActive and not self.isRemoteSynthConfigured:
+			return
+		assert self._nvdaHandlePostConfigProfileSwitch is not None
+		self._nvdaHandlePostConfigProfileSwitch(resetSpeechIfNeeded)
 
 	def _handleRemoteDisconnect(self, synth: remoteSynthDriver):
 		log.error(f"Handling remote disconnect for {synth!r}")
@@ -112,6 +156,7 @@ class SynthDetector(AutoPropertyObject):
 		self._queueBgScan(force)
 
 	def terminate(self):
+		self._restorePostConfigProfileSwitch()
 		remoteSynthDriver.synthRemoteDisconnected.unregister(self._handleRemoteDisconnect)
 		self._stopBgScan()
 		self._executor.shutdown(wait=False)

--- a/buildVars.py
+++ b/buildVars.py
@@ -30,7 +30,7 @@ addon_info = AddonInfo(
 		+ "Citrix Workspace, Parallels RAS and VMware Horizon",
 	),
 	# version
-	addon_version="2.0.0",
+	addon_version="2.0.1",
 	# Brief changelog for this version
 	# Translators: what's new content for the add-on version to be shown in the add-on store
 	addon_changelog=_(""),

--- a/readme.md
+++ b/readme.md
@@ -109,10 +109,11 @@ Choose between:
 To ensure a smooth start with the add-on, all options are enabled by default.
 However, you are encouraged to disable server or client mode as appropriate.
 
-### Automatically Recover Remote Speech after Connection Loss
+### Automatically Switch to Remote Speech when Available
 
 This option is only available in server mode.
-It ensures that the connection will automatically be re-established when the Remote Speech synthesizer is active and the connection is lost, similar to braille display auto-detection.
+It ensures that Remote Speech is activated as soon as a remote desktop client offers it, similar to braille display auto-detection, and that the connection is automatically re-established when it is lost.
+While Remote Speech is active this way, your configured synthesizer is left untouched, and switching configuration profiles no longer falls back to it.
 
 This option is enabled by default.
 It is strongly encouraged to leave this option enabled if the Remote Desktop server has no audio output.

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,11 @@ This enables a user experience where managing a remote system feels as seamless 
 
 ## Changelog
 
+### Version 2.0.1
+
+* When remote speech is switched on automatically, it now keeps speaking after a configuration profile switch. Previously, NVDA fell back to the synthesizer you have configured as soon as a profile was activated, for example when you moved to an application with its own profile.
+* Renamed the option "Automatically recover remote speech after connection loss" to "Automatically switch to remote speech when available", which better describes what it does.
+
 ### Version 2.0
 
 * Speech and braille coming from the remote system are now presented sooner, which makes working in a remote session feel more responsive.


### PR DESCRIPTION
## Problem

When NVDA on the remote desktop server starts with a synthesizer other than Remote Speech configured, `SynthDetector` activates the remote synth by assigning `synthDriverHandler._curSynth` directly, deliberately leaving `config.conf["speech"]["synth"]` alone.

NVDA''s `synthDriverHandler.handlePostConfigProfileSwitch` assumes `_curSynth` always mirrors config:

```python
if conf["synth"] != _curSynth.name or config.conf["audio"]["outputDevice"] != _audioOutputDevice:
    ...
    setSynth(conf["synth"])
    return
```

So every configuration profile switch cancelled and terminated the remote synth and loaded the configured one. Nothing recovered it either: `event_gainFocus` triggers a rescan without `force`, and `_queueBgScan` bails out unless remote speech is the configured synthesizer. Only a lock state change forced a rescan.

Setting Remote Speech as the configured synthesizer would fix the mismatch, but writing real config is not acceptable here.

## Fix

For as long as a `SynthDetector` is alive, it takes NVDA''s handler over and skips the synthesizer reload while remote speech is active without being configured.

Both the extension point registration and the module attribute are replaced. `Action.register` stores a reference to the function object itself, so patching the module attribute alone would leave the registered handler untouched, while only re-registering would leave the three direct calls in `speech.manager` (profile triggers inside a speech sequence) unhandled. Our handler is moved to the start of the registration order; NVDA registers its own second, and an `OrderedDict` cannot re-insert at an index.

The original handler and its registration are restored on `terminate()`, which is reached both when server mode is disabled and when the setting below is switched off.

The suppressed branch simply returns. `RemoteDriver.loadSettings` only touches `_localSettings`, i.e. `fallbackSynth`, and `_fallback` reads that value straight out of `config.conf["speech"]["remote"]` rather than off the driver, so there is nothing to re-sync.

Braille is unaffected: the remote display is auto-detected through NVDA''s standard mechanism with `config.conf["braille"]["display"] == "auto"`, which `brailleHandler.handlePostConfigProfileSwitch` already preserves via `_lastRequestedDisplayName`.

## Setting renamed

"Automatically recover remote speech after connection loss" is now "Automatically switch to remote speech when available", since the option governs activation, recovery and surviving profile switches. The config key `recoverRemoteSpeech` is unchanged, so existing configurations keep their value.

## Testing

`prek run --all-files` passes (ruff, ty, 202 unit tests). `synthDetect` cannot be imported by the test harness, so this path is verified manually against a real session: connect with eSpeak configured on the server, confirm speech moves to the client, then activate a profile manually and by focusing an app, and confirm speech stays remote and the log shows no `Loaded synthDriver espeak`. Disconnecting still falls back per `fallbackSynth`, and turning the option off restores NVDA''s stock behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)