### PR TITLE
Report the client synthesizer's available languages to the remote synth driver

### DIFF
--- a/addon/globalPlugins/rdAccess/handlers/remoteSpeechHandler.py
+++ b/addon/globalPlugins/rdAccess/handlers/remoteSpeechHandler.py
@@ -57,22 +57,22 @@ class RemoteSpeechHandler(RemoteHandler[synthDriverHandler.SynthDriver]):
 			language = self._driver.language
 		return language
 
-	@protocol.attributeSender(protocol.SpeechAttribute.SUPPORTED_LANGUAGES)
-	def _outgoing_supportedLanguages(
+	@protocol.attributeSender(protocol.SpeechAttribute.AVAILABLE_LANGUAGES)
+	def _outgoing_availableLanguages(
 		self,
 		languages: list[str | None] | None = None,
 	) -> list[str | None]:
 		if languages is None:
-			languages = self._getSupportedLanguages(self._driver)
+			languages = self._getAvailableLanguages(self._driver)
 		return languages
 
 	@staticmethod
-	def _getSupportedLanguages(synth: synthDriverHandler.SynthDriver) -> list[str | None]:
+	def _getAvailableLanguages(synth: synthDriverHandler.SynthDriver) -> list[str | None]:
 		try:
 			languages = synth.availableLanguages
 		except NotImplementedError:
 			languages = {synth.language}
-		return protocol.speech.encodeSupportedLanguages(languages)
+		return protocol.speech.encodeAvailableLanguages(languages)
 
 	@protocol.commandHandler(protocol.RdMessageType.SPEAK)
 	def _command_speak(self, sequence: SpeechSequence):
@@ -136,6 +136,6 @@ class RemoteSpeechHandler(RemoteHandler[synthDriverHandler.SynthDriver]):
 		)
 		self._attributeSenderStore(protocol.SpeechAttribute.LANGUAGE, language=synth.language)
 		self._attributeSenderStore(
-			protocol.SpeechAttribute.SUPPORTED_LANGUAGES,
-			languages=self._getSupportedLanguages(synth),
+			protocol.SpeechAttribute.AVAILABLE_LANGUAGES,
+			languages=self._getAvailableLanguages(synth),
 		)

--- a/addon/globalPlugins/rdAccess/handlers/remoteSpeechHandler.py
+++ b/addon/globalPlugins/rdAccess/handlers/remoteSpeechHandler.py
@@ -57,6 +57,23 @@ class RemoteSpeechHandler(RemoteHandler[synthDriverHandler.SynthDriver]):
 			language = self._driver.language
 		return language
 
+	@protocol.attributeSender(protocol.SpeechAttribute.SUPPORTED_LANGUAGES)
+	def _outgoing_supportedLanguages(
+		self,
+		languages: list[str | None] | None = None,
+	) -> list[str | None]:
+		if languages is None:
+			languages = self._getSupportedLanguages(self._driver)
+		return languages
+
+	@staticmethod
+	def _getSupportedLanguages(synth: synthDriverHandler.SynthDriver) -> list[str | None]:
+		try:
+			languages = synth.availableLanguages
+		except NotImplementedError:
+			languages = {synth.language}
+		return protocol.speech.encodeSupportedLanguages(languages)
+
 	@protocol.commandHandler(protocol.RdMessageType.SPEAK)
 	def _command_speak(self, sequence: SpeechSequence):
 		self._queueFunctionOnMainThread(self._speak, sequence, _immediate=True)
@@ -118,3 +135,7 @@ class RemoteSpeechHandler(RemoteHandler[synthDriverHandler.SynthDriver]):
 			commands=synth.supportedCommands,
 		)
 		self._attributeSenderStore(protocol.SpeechAttribute.LANGUAGE, language=synth.language)
+		self._attributeSenderStore(
+			protocol.SpeechAttribute.SUPPORTED_LANGUAGES,
+			languages=self._getSupportedLanguages(synth),
+		)

--- a/addon/lib/protocol/speech.py
+++ b/addon/lib/protocol/speech.py
@@ -27,19 +27,20 @@ class SpeechCommand(IntEnum):
 class SpeechAttribute(StrEnum):
 	SUPPORTED_COMMANDS = "supportedCommands"
 	LANGUAGE = "language"
-	SUPPORTED_LANGUAGES = "supportedLanguages"
+	AVAILABLE_LANGUAGES = "_availableLanguages"
+	"""Leading underscore keeps the name outside the ``available*s`` setting values namespace."""
 
 
-def encodeSupportedLanguages(languages: Iterable[str | None]) -> list[str | None]:
-	"""Encode a supported languages set as a deterministically ordered, JSON-safe list.
+def encodeAvailableLanguages(languages: Iterable[str | None]) -> list[str | None]:
+	"""Encode an available languages set as a deterministically ordered, JSON-safe list.
 
 	``None`` sorts last.
 	"""
 	return sorted(languages, key=lambda lang: (lang is None, lang or ""))
 
 
-def decodeSupportedLanguages(value: object, fallback: AbstractSet[str | None]) -> set[str | None]:
-	"""Decode an incoming supported languages value to a set.
+def decodeAvailableLanguages(value: object, fallback: AbstractSet[str | None]) -> set[str | None]:
+	"""Decode an incoming available languages value to a set.
 
 	Members other than ``str`` and ``None`` are dropped; a malformed or empty value
 	decodes to a copy of ``fallback``.

--- a/addon/lib/protocol/speech.py
+++ b/addon/lib/protocol/speech.py
@@ -10,7 +10,7 @@ from enum import IntEnum, StrEnum
 from speech.commands import BaseCallbackCommand, IndexCommand
 
 if typing.TYPE_CHECKING:
-	from collections.abc import Callable
+	from collections.abc import Callable, Iterable, Set as AbstractSet
 
 	from speech.types import SpeechSequence
 
@@ -27,6 +27,27 @@ class SpeechCommand(IntEnum):
 class SpeechAttribute(StrEnum):
 	SUPPORTED_COMMANDS = "supportedCommands"
 	LANGUAGE = "language"
+	SUPPORTED_LANGUAGES = "supportedLanguages"
+
+
+def encodeSupportedLanguages(languages: Iterable[str | None]) -> list[str | None]:
+	"""Encode a supported languages set as a deterministically ordered, JSON-safe list.
+
+	``None`` (a voice without language information) sorts last.
+	"""
+	return sorted(languages, key=lambda lang: (lang is None, lang or ""))
+
+
+def decodeSupportedLanguages(value: object, fallback: AbstractSet[str | None]) -> set[str | None]:
+	"""Decode an incoming supported languages value to a set.
+
+	Members other than ``str`` and ``None`` are dropped; a malformed or empty value
+	decodes to a copy of ``fallback``.
+	"""
+	if not isinstance(value, (list, tuple, set, frozenset)):
+		return set(fallback)
+	languages = {lang for lang in value if lang is None or isinstance(lang, str)}
+	return languages or set(fallback)
 
 
 class RemoteIndexCallbackCommand(BaseCallbackCommand):

--- a/addon/lib/protocol/speech.py
+++ b/addon/lib/protocol/speech.py
@@ -33,7 +33,7 @@ class SpeechAttribute(StrEnum):
 def encodeSupportedLanguages(languages: Iterable[str | None]) -> list[str | None]:
 	"""Encode a supported languages set as a deterministically ordered, JSON-safe list.
 
-	``None`` (a voice without language information) sorts last.
+	``None`` sorts last.
 	"""
 	return sorted(languages, key=lambda lang: (lang is None, lang or ""))
 

--- a/addon/synthDrivers/remote.py
+++ b/addon/synthDrivers/remote.py
@@ -37,6 +37,7 @@ class remoteSynthDriver(driver.RemoteDriver, synthDriverHandler.SynthDriver):
 		synthDriverHandler.synthDoneSpeaking,
 	}
 	driverType = protocol.DriverType.SPEECH
+	_availableVoices: typing.ClassVar[OrderedDict[str, synthDriverHandler.VoiceInfo]] = OrderedDict()
 	synthRemoteDisconnected = Action()
 	fallbackSynth: str = AUTOMATIC_PORT[0]
 	_localSettings: typing.ClassVar = [
@@ -129,19 +130,16 @@ class remoteSynthDriver(driver.RemoteDriver, synthDriverHandler.SynthDriver):
 	def _get_language(self):
 		return self._getRemoteAttributeValueWithFallback(protocol.SpeechAttribute.LANGUAGE)
 
-	@protocol.attributeReceiver(protocol.SpeechAttribute.SUPPORTED_LANGUAGES)
-	def _incoming_supportedLanguages(self, languages: list[str | None]) -> set[str | None]:
-		return protocol.speech.decodeSupportedLanguages(languages, {self.language})
+	@protocol.attributeReceiver(protocol.SpeechAttribute.AVAILABLE_LANGUAGES)
+	def _incoming_availableLanguages(self, languages: list[str | None]) -> set[str | None]:
+		return protocol.speech.decodeAvailableLanguages(languages, {self.language})
 
-	@_incoming_supportedLanguages.defaultValueGetter
-	def _default_supportedLanguages(self, _attribute: str) -> set[str | None]:
+	@_incoming_availableLanguages.defaultValueGetter
+	def _default_availableLanguages(self, _attribute: str) -> set[str | None]:
 		return {self.language}
 
 	def _get_availableLanguages(self) -> set[str | None]:
-		return self._getRemoteAttributeValueWithFallback(protocol.SpeechAttribute.SUPPORTED_LANGUAGES)
-
-	def _getAvailableVoices(self) -> OrderedDict[str, synthDriverHandler.VoiceInfo]:
-		return OrderedDict()
+		return self._getRemoteAttributeValueWithFallback(protocol.SpeechAttribute.AVAILABLE_LANGUAGES)
 
 	@protocol.commandHandler(protocol.RdMessageType.INDEX)
 	def _command_indexReached(self, index: int):

--- a/addon/synthDrivers/remote.py
+++ b/addon/synthDrivers/remote.py
@@ -129,6 +129,20 @@ class remoteSynthDriver(driver.RemoteDriver, synthDriverHandler.SynthDriver):
 	def _get_language(self):
 		return self._getRemoteAttributeValueWithFallback(protocol.SpeechAttribute.LANGUAGE)
 
+	@protocol.attributeReceiver(protocol.SpeechAttribute.SUPPORTED_LANGUAGES)
+	def _incoming_supportedLanguages(self, languages: list[str | None]) -> set[str | None]:
+		return protocol.speech.decodeSupportedLanguages(languages, {self.language})
+
+	@_incoming_supportedLanguages.defaultValueGetter
+	def _default_supportedLanguages(self, _attribute: str) -> set[str | None]:
+		return {self.language}
+
+	def _get_availableLanguages(self) -> set[str | None]:
+		return self._getRemoteAttributeValueWithFallback(protocol.SpeechAttribute.SUPPORTED_LANGUAGES)
+
+	def _getAvailableVoices(self) -> OrderedDict[str, synthDriverHandler.VoiceInfo]:
+		return OrderedDict()
+
 	@protocol.commandHandler(protocol.RdMessageType.INDEX)
 	def _command_indexReached(self, index: int):
 		if index:

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 * Speech and braille coming from the remote system are now presented sooner, which makes working in a remote session feel more responsive.
+* Fixed frequent errors on the remote system when automatic language switching was enabled while using the remote synthesizer. Reporting of unsupported languages now reflects the languages supported by the speech synthesizer on the client.
 * When starting a remote server instance of NVDA, braille is now shown as soon as a remote session connects, instead of only after the first keypress or focus change.
 * Fixed a freeze when switching away from the remote synthesizer or braille display while a session was disconnecting.
 * RDAccess now exchanges speech and braille using a new protocol modeled on the one used by NVDA's built-in Remote Access. It is more robust and no longer relies on the pickle format that a compromised remote system could abuse. The protocol version is chosen automatically, so a client and a server running different versions of RDAccess still work together.

--- a/tests/test_availableLanguages.py
+++ b/tests/test_availableLanguages.py
@@ -2,7 +2,7 @@
 # Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
 # License: GNU General Public License version 2.0 or later
 
-"""Unit tests for the ``supportedLanguages`` speech attribute helpers in ``lib.protocol.speech``."""
+"""Unit tests for the ``_availableLanguages`` speech attribute helpers in ``lib.protocol.speech``."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ import unittest
 
 from lib import protocol
 from lib.protocol import legacy
-from lib.protocol.speech import decodeSupportedLanguages, encodeSupportedLanguages
+from lib.protocol.speech import decodeAvailableLanguages, encodeAvailableLanguages
 
 from tests._fakes import FakeHandlerBase, buildMessage
 
@@ -30,91 +30,91 @@ class AttributeNameTests(unittest.TestCase):
 		"""The wire name must not match the setting_* or available*s wildcard namespaces."""
 		from fnmatch import fnmatchcase
 
-		attribute = protocol.SpeechAttribute.SUPPORTED_LANGUAGES
-		self.assertEqual(attribute, "supportedLanguages")
+		attribute = protocol.SpeechAttribute.AVAILABLE_LANGUAGES
+		self.assertEqual(attribute, "_availableLanguages")
 		self.assertFalse(fnmatchcase(attribute, "available*s"))
 		self.assertFalse(fnmatchcase(attribute, protocol.SETTING_ATTRIBUTE_PREFIX + "*"))
 
 
 class EncodeTests(unittest.TestCase):
 	def test_returns_sorted_list(self):
-		self.assertEqual(encodeSupportedLanguages({"nl_NL", "en", "de"}), ["de", "en", "nl_NL"])
+		self.assertEqual(encodeAvailableLanguages({"nl_NL", "en", "de"}), ["de", "en", "nl_NL"])
 
 	def test_none_sorts_last(self):
-		self.assertEqual(encodeSupportedLanguages({None, "nl", "en"}), ["en", "nl", None])
+		self.assertEqual(encodeAvailableLanguages({None, "nl", "en"}), ["en", "nl", None])
 
 
 class DecodeTests(unittest.TestCase):
 	def test_list_becomes_set(self):
-		self.assertEqual(decodeSupportedLanguages(["en", "nl"], {"fr"}), {"en", "nl"})
+		self.assertEqual(decodeAvailableLanguages(["en", "nl"], {"fr"}), {"en", "nl"})
 
 	def test_set_input_accepted(self):
 		"""The legacy pickle path may deliver a set rather than a list."""
-		self.assertEqual(decodeSupportedLanguages({"en"}, {"fr"}), {"en"})
+		self.assertEqual(decodeAvailableLanguages({"en"}, {"fr"}), {"en"})
 
 	def test_none_member_preserved(self):
 		"""A voice without language yields None; a meaningful value, not absence of data."""
-		self.assertEqual(decodeSupportedLanguages([None], {"fr"}), {None})
+		self.assertEqual(decodeAvailableLanguages([None], {"fr"}), {None})
 
 	def test_empty_falls_back(self):
-		self.assertEqual(decodeSupportedLanguages([], {"fr"}), {"fr"})
+		self.assertEqual(decodeAvailableLanguages([], {"fr"}), {"fr"})
 
 	def test_mapping_falls_back(self):
 		"""An old peer's available*s wildcard sender answers with a (possibly empty) dict."""
-		self.assertEqual(decodeSupportedLanguages({}, {"fr"}), {"fr"})
-		self.assertEqual(decodeSupportedLanguages({"en": "English"}, {"fr"}), {"fr"})
+		self.assertEqual(decodeAvailableLanguages({}, {"fr"}), {"fr"})
+		self.assertEqual(decodeAvailableLanguages({"en": "English"}, {"fr"}), {"fr"})
 
 	def test_string_falls_back(self):
 		"""A bare string must not be iterated into characters."""
-		self.assertEqual(decodeSupportedLanguages("en", {"fr"}), {"fr"})
+		self.assertEqual(decodeAvailableLanguages("en", {"fr"}), {"fr"})
 
 	def test_non_string_members_dropped(self):
-		self.assertEqual(decodeSupportedLanguages(["en", 42], {"fr"}), {"en"})
+		self.assertEqual(decodeAvailableLanguages(["en", 42], {"fr"}), {"en"})
 
 	def test_only_invalid_members_falls_back(self):
-		self.assertEqual(decodeSupportedLanguages([42], {"fr"}), {"fr"})
+		self.assertEqual(decodeAvailableLanguages([42], {"fr"}), {"fr"})
 
 	def test_fallback_returned_as_copy(self):
 		fallback = {"fr"}
-		result = decodeSupportedLanguages([], fallback)
+		result = decodeAvailableLanguages([], fallback)
 		result.add("xx")
 		self.assertEqual(fallback, {"fr"})
 
 
-class SupportedLanguagesReceiver(FakeHandlerBase):
-	@protocol.attributeReceiver(protocol.SpeechAttribute.SUPPORTED_LANGUAGES)
-	def _incoming_supportedLanguages(self, languages) -> set[str | None]:
-		return decodeSupportedLanguages(languages, {"en"})
+class AvailableLanguagesReceiver(FakeHandlerBase):
+	@protocol.attributeReceiver(protocol.SpeechAttribute.AVAILABLE_LANGUAGES)
+	def _incoming_availableLanguages(self, languages) -> set[str | None]:
+		return decodeAvailableLanguages(languages, {"en"})
 
-	@_incoming_supportedLanguages.defaultValueGetter
-	def _default_supportedLanguages(self, _attribute: protocol.AttributeT) -> set[str | None]:
+	@_incoming_availableLanguages.defaultValueGetter
+	def _default_availableLanguages(self, _attribute: protocol.AttributeT) -> set[str | None]:
 		return {"en"}
 
 
 class ReceiverIntegrationTests(unittest.TestCase):
 	def setUp(self):
-		self.handler = SupportedLanguagesReceiver()
+		self.handler = AvailableLanguagesReceiver()
 		self.addCleanup(self.handler.terminate)
 
 	def test_push_stores_normalized_set(self):
-		self.handler._onReceive(_attrPush(protocol.SpeechAttribute.SUPPORTED_LANGUAGES, ["nl", "de"]))
+		self.handler._onReceive(_attrPush(protocol.SpeechAttribute.AVAILABLE_LANGUAGES, ["nl", "de"]))
 		value = self.handler._attributeValueProcessor.getValue(
-			protocol.SpeechAttribute.SUPPORTED_LANGUAGES,
+			protocol.SpeechAttribute.AVAILABLE_LANGUAGES,
 			fallBackToDefault=False,
 		)
 		self.assertEqual(value, {"nl", "de"})
 
 	def test_default_before_first_push(self):
 		value = self.handler._attributeValueProcessor.getValue(
-			protocol.SpeechAttribute.SUPPORTED_LANGUAGES,
+			protocol.SpeechAttribute.AVAILABLE_LANGUAGES,
 			fallBackToDefault=True,
 		)
 		self.assertEqual(value, {"en"})
 
 	def test_pushed_empty_value_stores_fallback(self):
-		self.handler._onReceive(_attrPush(protocol.SpeechAttribute.SUPPORTED_LANGUAGES, []))
+		self.handler._onReceive(_attrPush(protocol.SpeechAttribute.AVAILABLE_LANGUAGES, []))
 		value = self.handler._attributeValueProcessor.getValue(
-			protocol.SpeechAttribute.SUPPORTED_LANGUAGES,
+			protocol.SpeechAttribute.AVAILABLE_LANGUAGES,
 			fallBackToDefault=False,
 		)
 		self.assertEqual(value, {"en"})

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -15,6 +15,7 @@ from autoSettingsUtils.driverSetting import BooleanDriverSetting, DriverSetting,
 from autoSettingsUtils.utils import StringParameterInfo
 from lib.protocol.messages import RdMessageType
 from lib.protocol.serializer import RdJSONSerializer
+from lib.protocol.speech import SpeechAttribute
 from logHandler import log
 from synthDriverHandler import VoiceInfo
 
@@ -149,6 +150,14 @@ class SupportedCommandsTests(SerializerTestCase):
 		)
 		decoded = self.serializer.deserialize(data)["value"]
 		self.assertEqual(decoded, frozenset((speech.commands.IndexCommand,)))
+
+
+class SupportedLanguagesTests(SerializerTestCase):
+	def test_listPassesThroughUntouched(self):
+		"""Must not hit _decodeAvailableValues despite naming a language capability."""
+		languages = ["en", "nl_NL", None]
+		decoded = self.roundTripAttribute(SpeechAttribute.SUPPORTED_LANGUAGES, languages)
+		self.assertEqual(decoded, languages)
 
 
 class GestureMapTests(SerializerTestCase):

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -152,11 +152,11 @@ class SupportedCommandsTests(SerializerTestCase):
 		self.assertEqual(decoded, frozenset((speech.commands.IndexCommand,)))
 
 
-class SupportedLanguagesTests(SerializerTestCase):
+class AvailableLanguagesTests(SerializerTestCase):
 	def test_listPassesThroughUntouched(self):
 		"""Must not hit _decodeAvailableValues despite naming a language capability."""
 		languages = ["en", "nl_NL", None]
-		decoded = self.roundTripAttribute(SpeechAttribute.SUPPORTED_LANGUAGES, languages)
+		decoded = self.roundTripAttribute(SpeechAttribute.AVAILABLE_LANGUAGES, languages)
 		self.assertEqual(decoded, languages)
 
 

--- a/tests/test_supportedLanguages.py
+++ b/tests/test_supportedLanguages.py
@@ -1,0 +1,124 @@
+# RDAccess: Remote Desktop Accessibility for NVDA
+# Copyright 2026 Leonard de Ruijter <alderuijter@gmail.com>
+# License: GNU General Public License version 2.0 or later
+
+"""Unit tests for the ``supportedLanguages`` speech attribute helpers in ``lib.protocol.speech``."""
+
+from __future__ import annotations
+
+import unittest
+
+from lib import protocol
+from lib.protocol import legacy
+from lib.protocol.speech import decodeSupportedLanguages, encodeSupportedLanguages
+
+from tests._fakes import FakeHandlerBase, buildMessage
+
+
+def _attrPush(attribute: str, value) -> bytes:
+	payload = (
+		protocol.ATTRIBUTE_SEPARATOR
+		+ attribute.encode("ASCII")
+		+ protocol.ATTRIBUTE_SEPARATOR
+		+ legacy.encodeAttributeValue(attribute, value)
+	)
+	return buildMessage(protocol.DriverType.SPEECH, protocol.GenericCommand.ATTRIBUTE, payload)
+
+
+class AttributeNameTests(unittest.TestCase):
+	def test_name_outside_settings_namespaces(self):
+		"""The wire name must not match the setting_* or available*s wildcard namespaces."""
+		from fnmatch import fnmatchcase
+
+		attribute = protocol.SpeechAttribute.SUPPORTED_LANGUAGES
+		self.assertEqual(attribute, "supportedLanguages")
+		self.assertFalse(fnmatchcase(attribute, "available*s"))
+		self.assertFalse(fnmatchcase(attribute, protocol.SETTING_ATTRIBUTE_PREFIX + "*"))
+
+
+class EncodeTests(unittest.TestCase):
+	def test_returns_sorted_list(self):
+		self.assertEqual(encodeSupportedLanguages({"nl_NL", "en", "de"}), ["de", "en", "nl_NL"])
+
+	def test_none_sorts_last(self):
+		self.assertEqual(encodeSupportedLanguages({None, "nl", "en"}), ["en", "nl", None])
+
+
+class DecodeTests(unittest.TestCase):
+	def test_list_becomes_set(self):
+		self.assertEqual(decodeSupportedLanguages(["en", "nl"], {"fr"}), {"en", "nl"})
+
+	def test_set_input_accepted(self):
+		"""The legacy pickle path may deliver a set rather than a list."""
+		self.assertEqual(decodeSupportedLanguages({"en"}, {"fr"}), {"en"})
+
+	def test_none_member_preserved(self):
+		"""A voice without language yields None; a meaningful value, not absence of data."""
+		self.assertEqual(decodeSupportedLanguages([None], {"fr"}), {None})
+
+	def test_empty_falls_back(self):
+		self.assertEqual(decodeSupportedLanguages([], {"fr"}), {"fr"})
+
+	def test_mapping_falls_back(self):
+		"""An old peer's available*s wildcard sender answers with a (possibly empty) dict."""
+		self.assertEqual(decodeSupportedLanguages({}, {"fr"}), {"fr"})
+		self.assertEqual(decodeSupportedLanguages({"en": "English"}, {"fr"}), {"fr"})
+
+	def test_string_falls_back(self):
+		"""A bare string must not be iterated into characters."""
+		self.assertEqual(decodeSupportedLanguages("en", {"fr"}), {"fr"})
+
+	def test_non_string_members_dropped(self):
+		self.assertEqual(decodeSupportedLanguages(["en", 42], {"fr"}), {"en"})
+
+	def test_only_invalid_members_falls_back(self):
+		self.assertEqual(decodeSupportedLanguages([42], {"fr"}), {"fr"})
+
+	def test_fallback_returned_as_copy(self):
+		fallback = {"fr"}
+		result = decodeSupportedLanguages([], fallback)
+		result.add("xx")
+		self.assertEqual(fallback, {"fr"})
+
+
+class SupportedLanguagesReceiver(FakeHandlerBase):
+	@protocol.attributeReceiver(protocol.SpeechAttribute.SUPPORTED_LANGUAGES)
+	def _incoming_supportedLanguages(self, languages) -> set[str | None]:
+		return decodeSupportedLanguages(languages, {"en"})
+
+	@_incoming_supportedLanguages.defaultValueGetter
+	def _default_supportedLanguages(self, _attribute: protocol.AttributeT) -> set[str | None]:
+		return {"en"}
+
+
+class ReceiverIntegrationTests(unittest.TestCase):
+	def setUp(self):
+		self.handler = SupportedLanguagesReceiver()
+		self.addCleanup(self.handler.terminate)
+
+	def test_push_stores_normalized_set(self):
+		self.handler._onReceive(_attrPush(protocol.SpeechAttribute.SUPPORTED_LANGUAGES, ["nl", "de"]))
+		value = self.handler._attributeValueProcessor.getValue(
+			protocol.SpeechAttribute.SUPPORTED_LANGUAGES,
+			fallBackToDefault=False,
+		)
+		self.assertEqual(value, {"nl", "de"})
+
+	def test_default_before_first_push(self):
+		value = self.handler._attributeValueProcessor.getValue(
+			protocol.SpeechAttribute.SUPPORTED_LANGUAGES,
+			fallBackToDefault=True,
+		)
+		self.assertEqual(value, {"en"})
+
+	def test_pushed_empty_value_stores_fallback(self):
+		self.handler._onReceive(_attrPush(protocol.SpeechAttribute.SUPPORTED_LANGUAGES, []))
+		value = self.handler._attributeValueProcessor.getValue(
+			protocol.SpeechAttribute.SUPPORTED_LANGUAGES,
+			fallBackToDefault=False,
+		)
+		self.assertEqual(value, {"en"})
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
Fixes #75.

## What exists

NVDA can switch synthesizer languages automatically while reading. To decide whether to announce a language as unsupported, it asks the active synthesizer for the set of languages it supports. This check runs for almost every utterance and has no error handling; NVDA expects every synthesizer driver to answer it.

The remote synthesizer driver runs on the remote system and forwards speech to the client, where the real synthesizer speaks. The driver only learns the client synthesizer's voices and languages when driver settings management is enabled. That option is off by default. Without that data, the language question falls through to NVDA's abstract base implementation, which raises an error. The result is an error logged (and an error sound played on test builds) on nearly every utterance.

## What is needed

The remote synthesizer driver must always be able to answer which languages it supports, regardless of the driver settings management option. Ideally the answer reflects the real synthesizer on the client, so that "language not supported" announcements are accurate.

## What changes

* The connection protocol gains a speech attribute that carries the languages of the client's synthesizer, named `_availableLanguages` (`SpeechAttribute.AVAILABLE_LANGUAGES`). The leading underscore keeps the name outside the `available…s` namespace, which is reserved for lists of driver setting values and handled by wildcard logic in several places.
* The client sends this list when a session connects and again whenever its synthesizer changes, and answers requests for it (`RemoteSpeechHandler._outgoing_availableLanguages`). This happens independently of the driver settings management option.
* The remote synthesizer driver stores the received list and reports it to NVDA as its available languages (`remoteSynthDriver._get_availableLanguages`). While no answer has arrived yet, or when the client runs an older RDAccess version that cannot answer, the driver falls back to the single language the client already reports today.
* The driver also presets an empty voice list through the `_availableVoices` class attribute, as NVDA's silence synthesizer does, so no other code path can reach NVDA's abstract implementation and hit the same error.
* Two helper functions convert between the wire format and the value NVDA expects: one encodes the language set as a stably ordered list, the other decodes an incoming value back to a set and falls back safely when the value is empty or malformed, as older versions may send (`encodeAvailableLanguages` / `decodeAvailableLanguages` in `lib/protocol/speech.py`).

## Tests

The new tests cover: the attribute name staying outside the wildcard namespaces used for driver settings; encoding to a stably ordered list, including voices without a language; decoding back to a set with fallbacks for empty, malformed, or wrongly typed values; receiving a pushed value through the wire protocol; and the serializer passing the new attribute through unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
